### PR TITLE
Fix clean's behavior

### DIFF
--- a/src/commands/modCommands/clean.js
+++ b/src/commands/modCommands/clean.js
@@ -23,8 +23,9 @@ module.exports = new GenericModerationCommand(
         }
         break
 
-      default: // No arguments/matches, default to cleaning Memer's messages
+      case 'memer':
         filter = (m) => m.author.id === Memer.bot.user.id
+        break
     }
 
     const deleted = await msg.channel.purge(purgeAmount, filter)
@@ -44,7 +45,7 @@ module.exports = new GenericModerationCommand(
   },
   {
     triggers: ['clean', 'purge', 'clear'],
-    usage: '{command} [amount] [bots|users] [users...]',
+    usage: '{command} [amount] [bots|users|memer] [users...]',
     description: 'Will quickly clean the last 10 messages, or however many you specify.',
     perms: ['manageMessages', 'readMessageHistory'],
     modPerms: ['manageMessages']


### PR DESCRIPTION
The behavior of the clean command was to default to memer's message when no filter is specified, as it isn't even specified in the help, it was leading to confusing results, like `0 messages deleted` when doing `pls clean 2` for example.

This PR change this behavior to default to all messages instead, as it makes more sense, and add a `memer` filter to only target memer's message