### PR TITLE
Make "sec" autoreponse not match everything that starts with "sec"

### DIFF
--- a/src/handlers/messageCreate.js
+++ b/src/handlers/messageCreate.js
@@ -42,7 +42,7 @@ exports.handle = async function (msg) {
   }
 
   if (gConfig.autoResponse.sec) {
-    let re = /^(one sec|one second|sec)/i
+    let re = /^(one sec$|one second|sec$)/i
     const match = re.exec(msg.content)
     if (match) {
       await this.sleep(1000)


### PR DESCRIPTION
Add the `$` character to only match `sec` when it is the end of the input, this combined with `^`  basically makes it only match exact occurences of `sec`

Added to `one sec` as well because it was the one being matched when `one second` was in the string.

So as of now, the `sec` autoresponse is only triggered when the message is exactly either `one sec`, `one second` or `sec` (still case-insensitive ofc)