### PR TITLE
Add more statistics to `pls debug`

### DIFF
--- a/src/commands/infoCommands/debug.js
+++ b/src/commands/infoCommands/debug.js
@@ -1,5 +1,7 @@
 const os = require('os')
 const { GenericCommand } = require('../../models/')
+const { promisify } = require('util')
+const exec = promisify(require('child_process').exec)
 
 const getCPUUsage = async () => {
   const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
@@ -36,17 +38,40 @@ module.exports = new GenericCommand(
   async ({ Memer, msg }) => {
     const stats = await Memer.db.getStats()
     const CPUUsage = await getCPUUsage()
+    const gateway = await Memer.http.get(`https://discordapp.com/api/gateway/bot`, { headers: { 'Authorization': Memer.bot.token } })
+    const scan = async () => {
+      let cachedMessages = 0
+      let cursor = '0'
+      const keys = await Memer.redis.scanAsync(cursor, 'MATCH', 'msg-*', 'COUNT', '100')
+      if (!keys) {
+        throw keys
+      }
+      cursor = keys[0]
+      cachedMessages += keys[1].length
+      if (cursor === '0') {
+        return cachedMessages
+      } else {
+        return scan()
+      }
+    }
+
     const formatted =
     `[GUILDS] ${stats.guilds}\n` +
     `  [Large] ${stats.largeGuilds}\n` +
     `  [Exclusive] ${stats.exclusiveGuilds}\n` +
     `[USERS] ${stats.users}\n` +
     `  [Average] ${(stats.users / stats.guilds).toFixed()}\n` +
+    `[CACHED MESSAGES] ${await scan()}\n` +
     `[MEMORY] ${(stats.totalRam / 1000).toFixed(1)}/${(os.totalmem() / 1073741824).toFixed(1)}gb (${((stats.totalRam / 1000) / (os.totalmem() / 1073741824)).toFixed(1)}%)\n` +
     `  [System] ${((os.totalmem() - os.freemem()) / 1073741824).toFixed(1)}/${(os.totalmem() / 1073741824).toFixed(1)}gb (${(((os.totalmem() - os.freemem()) / os.totalmem()) * 100).toFixed(1)}%)\n` +
+    `  [Cluster] ${(stats.totalRam / 1000).toFixed(1) / Memer.config.sharder.clusters}gb\n` +
     `[UPTIME] ${Memer.parseTime(process.uptime())}\n` +
     `  [System] ${Memer.parseTime(os.uptime())}\n` +
-    `[CPU] ${CPUUsage.toFixed(1)}%\n`
+    `[CPU] ${CPUUsage.toFixed(1)}%\n` +
+    `[CONNECTIONS REMAINING] ${gateway.body.session_start_limit.remaining}\n` +
+    `  [TIME UNTIL RESET] ${Memer.parseTime(gateway.body.session_start_limit.reset_after / 1000)}\n` +
+    `[SFX] ${(await exec('$(find /home/memer/Dank-Memer/src/assets/audio/custom/ -type f | wc -l)')).stdout}\n` +
+    `  [Disk Space] ${(await exec('$(du -sh /home/memer/Dank-Memer/src/assets/audio/custom/ | cut -f1)')).stdout}`
 
     return '```ini\n' + formatted + '\n```'
   }, {

--- a/src/commands/infoCommands/debug.js
+++ b/src/commands/infoCommands/debug.js
@@ -36,13 +36,16 @@ const getCPUUsage = async () => {
 
 module.exports = new GenericCommand(
   async ({ Memer, msg }) => {
+    const sfxCount = await exec('$(find /home/memer/Dank-Memer/src/assets/audio/custom/ -type f | wc -l)').catch(() => 0)
+    const sfxSize = await exec('$(du -sh /home/memer/Dank-Memer/src/assets/audio/custom/ | cut -f1)').catch(() => 0)
+    console.log(sfxSize)
     const stats = await Memer.db.getStats()
     const CPUUsage = await getCPUUsage()
-    const gateway = await Memer.http.get(`https://discordapp.com/api/gateway/bot`, { headers: { 'Authorization': Memer.bot.token } })
+    const gateway = await Memer.bot.getBotGateway()
     const scan = async () => {
       let cachedMessages = 0
       let cursor = '0'
-      const keys = await Memer.redis.scanAsync(cursor, 'MATCH', 'msg-*', 'COUNT', '100')
+      const keys = await Memer.redis.scanAsync(cursor, 'MATCH', 'msg-*', 'COUNT', '50')
       if (!keys) {
         throw keys
       }
@@ -61,17 +64,20 @@ module.exports = new GenericCommand(
     `  [Exclusive] ${stats.exclusiveGuilds}\n` +
     `[USERS] ${stats.users}\n` +
     `  [Average] ${(stats.users / stats.guilds).toFixed()}\n` +
-    `[CACHED MESSAGES] ${await scan()}\n` +
+    `[MESSAGES] ${Memer.stats.messages}\n` +
+    `  [Cached] ${await scan()}\n` +
+    `[COMMANDS RAN] ${Memer.stats.commands}\n` +
+    `  [Average] ${Memer.stats.commands / stats.guilds}\n` +
     `[MEMORY] ${(stats.totalRam / 1000).toFixed(1)}/${(os.totalmem() / 1073741824).toFixed(1)}gb (${((stats.totalRam / 1000) / (os.totalmem() / 1073741824)).toFixed(1)}%)\n` +
     `  [System] ${((os.totalmem() - os.freemem()) / 1073741824).toFixed(1)}/${(os.totalmem() / 1073741824).toFixed(1)}gb (${(((os.totalmem() - os.freemem()) / os.totalmem()) * 100).toFixed(1)}%)\n` +
     `  [Cluster] ${(stats.totalRam / 1000).toFixed(1) / Memer.config.sharder.clusters}gb\n` +
     `[UPTIME] ${Memer.parseTime(process.uptime())}\n` +
     `  [System] ${Memer.parseTime(os.uptime())}\n` +
     `[CPU] ${CPUUsage.toFixed(1)}%\n` +
-    `[CONNECTIONS REMAINING] ${gateway.body.session_start_limit.remaining}\n` +
-    `  [TIME UNTIL RESET] ${Memer.parseTime(gateway.body.session_start_limit.reset_after / 1000)}\n` +
-    `[SFX] ${(await exec('$(find /home/memer/Dank-Memer/src/assets/audio/custom/ -type f | wc -l)')).stdout}\n` +
-    `  [Disk Space] ${(await exec('$(du -sh /home/memer/Dank-Memer/src/assets/audio/custom/ | cut -f1)')).stdout}`
+    `[CONNECTIONS REMAINING] ${gateway.session_start_limit.remaining}\n` +
+    `  [TIME UNTIL RESET] ${Memer.parseTime(gateway.session_start_limit.reset_after / 1000)}\n` +
+    `[SFX] ${sfxCount}\n` +
+    `  [Disk Space] ${sfxSize}`
 
     return '```ini\n' + formatted + '\n```'
   }, {

--- a/src/handlers/messageCreate.js
+++ b/src/handlers/messageCreate.js
@@ -10,6 +10,7 @@ exports.handle = async function (msg) {
     return
   }
 
+  this.stats.messages++
   cacheMessage.bind(this)(msg)
   const gConfig = await this.db.getGuild(msg.channel.guild.id) || {
     prefix: this.config.options.prefix,
@@ -233,6 +234,7 @@ function checkPerms (command, permissions, msg) {
 }
 
 async function runCommand (command, msg, args, cleanArgs, updateCooldowns) {
+  this.stats.commands++
   let res = await command.run({
     msg,
     args,

--- a/src/mainClass.js
+++ b/src/mainClass.js
@@ -69,6 +69,10 @@ class Memer extends Base {
 
     this.mentionRX = new RegExp(`^<@!*${this.bot.user.id}>`)
     this.mockIMG = await this.http.get('https://pbs.twimg.com/media/DAU-ZPHUIAATuNy.jpg').then(r => r.body)
+    this.stats = {
+      messages: 0,
+      commands: 0
+    }
   }
 
   createIPC () {


### PR DESCRIPTION
This PR adds more information and statistics to `pls debug`.

I've added more information such as the amount of SFX as well as the storage it takes up, gateway information, message count and command count (both average and total).

I didn't worry too much about adding the charts feature mentioned on the [Trello card](https://trello.com/c/tPpWuBtY/74-more-stats), however if this is something you'd still like to see, let me know and I'll work something out 👍 