### PR TITLE
Backlog to redis

### DIFF
--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -310,6 +310,16 @@ module.exports = {
     return pages
   },
 
+  paginateArray: (array, size) => {
+    let result = []
+    let j = 0
+    for (let i = 0; i < Math.ceil(array.length / (size || 10)); i++) {
+      result.push(array.slice(j, j + (size || 10)))
+      j = j + (size || 10)
+    }
+    return result
+  },
+
   format: seconds => {
     function pad (seconds) {
       return (seconds < 10 ? '0' : '') + seconds


### PR DESCRIPTION
**This PR is still experimental and some details should be discussed before the merge**

So, this PR is an attempt at drastically improving the speed of `pls rich` (and maybe other leaderboards in the future), especially on big guilds

**Note: This PR also changes the package used for redis from `redis` to `ioredis`**

# Benchmarks

The following tests were done on a guild with 30k members, with all of them being in the database, these tests at the moment only cover the local `pls rich`, and not the global (`pls rich -all`) 

* Current method used in production (directly using Rethink)
> 13998~14001ms

* Using a redis sorted set and the `redis` package
> 691~492ms

* Using a redis sorted set and the `ioredis` package
>393~376ms

This PR improves the speed of `pls rich` on big guilds by over `1000%`, and is also easier on the processor 

# Current downside

Because this solution establish a changes stream with RethinkDB that includes all the initial data (see `src/memer.js`), booting the bot will most likely use 100% of the processor for around 1 minute, as the 3 millions items in the `users` table will be inserted into the Redis sorted set

However this would only need to be done the first time to fill Redis, and all the following boots would not need to do this as the changes stream would only need to update the already existing data

(Currently need to find a way to make it automatically detect whether it needs to include initials though)
