### PR TITLE
Use webhooks instead of messages for autoposting

### DIFF
--- a/src/utils/Autopost.js
+++ b/src/utils/Autopost.js
@@ -2,6 +2,10 @@ module.exports = class Autopost {
   constructor (client) {
     /** @type {import("../models/GenericCommand").Memer} The memer instance */
     this.client = client
+    this.avatar = client.http.get(this.client.bot.user.dynamicAvatarURL())
+      .then(res => {
+        return `data:${res.headers['content-type']};base64,${res.body.toString('base64')}`
+      })
   }
 
   async getRedditPost () {
@@ -34,7 +38,7 @@ module.exports = class Autopost {
     for (const { channel } of check) {
       this.client.bot.createChannelWebhook(channel, {
         name: 'Automeme',
-        avatar: this.client.bot.user.dynamicAvatarURL('png')
+        avatar: await this.avatar
       }, 'Automeme Post').then(webhook => {
         this.client.bot.executeWebhook(webhook.id, webhook.token, {
           embeds: [ {
@@ -75,7 +79,7 @@ module.exports = class Autopost {
 
       this.client.bot.createChannelWebhook(channel, {
         name: 'Auto-NSFW',
-        avatar: this.client.bot.user.dynamicAvatarURL('png')
+        avatar: await this.avatar
       }, 'Auto-NSFW Post').then(webhook => {
         this.client.bot.executeWebhook(webhook.id, webhook.token, {
           embeds: [ {
@@ -85,6 +89,7 @@ module.exports = class Autopost {
           } ]
         })
           .then(() => {
+            this.client.log(webhook)
             this.client.bot.deleteWebhook(webhook.id, webhook.token, 'Auto-NSFW Post')
           })
           .catch((err) => {

--- a/src/utils/Autopost.js
+++ b/src/utils/Autopost.js
@@ -15,7 +15,6 @@ module.exports = class Autopost {
       'https://www.reddit.com/r/memes/top/.json?sort=top&t=day&limit=100',
       'https://www.reddit.com/r/meirl/top/.json?sort=top&t=day&limit=100',
       'https://www.reddit.com/r/dankmemes/top/.json?sort=top&t=day&limit=100',
-      'https://www.reddit.com/r/MemeEconomy/top/.json?sort=top&t=day&limit=100',
       'https://www.reddit.com/r/2meirl4meirl/top/.json?sort=top&t=day&limit=100',
       'https://www.reddit.com/r/PrequelMemes/top/.json?sort=top&t=day&limit=100',
       'https://www.reddit.com/r/surrealmemes/top/.json?sort=top&t=week&limit=100',
@@ -49,9 +48,6 @@ module.exports = class Autopost {
             footer: { text: `👍 ${post.data.ups} - 💬 ${post.data.num_comments} | ${post.data.subreddit}` }
           } ]
         })
-          .then(() => {
-            this.client.bot.deleteWebhook(webhook.id, webhook.token, 'Automeme Post')
-          })
           .catch((err) => {
             if (err.message.toString() === 'DiscordRESTError [10003]: Unknown Channel') {
               // Remove this channel from the database if it's not valid/not found
@@ -88,10 +84,6 @@ module.exports = class Autopost {
             footer: { text: 'Free nudes thanks to boobbot & tom <3' }
           } ]
         })
-          .then(() => {
-            this.client.log(webhook)
-            this.client.bot.deleteWebhook(webhook.id, webhook.token, 'Auto-NSFW Post')
-          })
           .catch((err) => {
             if (err.message.toString() === 'DiscordRESTError [10003]: Unknown Channel') {
               // Remove this channel from the database if it's not valid/not found


### PR DESCRIPTION
This PR introduces changes to autoposting that will create and execute a webhook rather than relying on chat messages for the content.

All functionality is the same, the only thing that's different is the appearance. The webhook name will represent the type of post the user is receiving.

This PR has been fully tested, all content and avatars should be working correctly.