### PR TITLE
Allow the user to choose the interval between posts on autoposting

### DIFF
--- a/src/commands/configCommands/automeme.js
+++ b/src/commands/configCommands/automeme.js
@@ -13,20 +13,22 @@ module.exports = new GenericCommand(
     if (!channel) {
       return 'come on you gotta give me a channel name or id to autopost memes to'
     }
+    let interval = Number(msg.args.gather()) || 5
+    Memer.log(interval)
 
     let check = await Memer.db.getAutomemeChannel(msg.channel.guild.id)
     if (check.channel === channel.id) {
       await Memer.db.removeAutomemeChannel(msg.channel.guild.id)
       return `I'll no longer autopost memes in <#${channel.id}>.`
     }
-    await Memer.db.addAutomemeChannel(msg.channel.guild.id, channel.id)
+    await Memer.db.addAutomemeChannel(msg.channel.guild.id, channel.id, interval)
     await addCD()
 
-    return check ? `Changed automeme channel from <#${check.channel}> to **<#${channel.id}>**` : `<#${channel.id}> will now post memes every 5 minutes`
+    return check ? `Changed automeme channel from <#${check.channel}> to **<#${channel.id}>**` : `<#${channel.id}> will now post memes every **${interval} minutes**`
   },
   {
     triggers: ['automeme'],
-    usage: '{command} [channel]',
+    usage: '{command} [channel] [interval in minutes]',
     cooldown: 1e4,
     donorBlocked: true,
     description: 'Set up a channel to automatically post memes to every 5 minutes'

--- a/src/commands/configCommands/automeme.js
+++ b/src/commands/configCommands/automeme.js
@@ -17,7 +17,6 @@ module.exports = new GenericCommand(
     if (!interval || !Number.isInteger(interval) || Number.isNaN(interval)) {
       interval = 5
     }
-    Memer.log(interval)
 
     let check = await Memer.db.getAutomemeChannel(msg.channel.guild.id)
     if (check.channel === channel.id) {

--- a/src/commands/configCommands/automeme.js
+++ b/src/commands/configCommands/automeme.js
@@ -24,7 +24,7 @@ module.exports = new GenericCommand(
     if (!interval || !Number.isInteger(interval) || Number.isNaN(interval) || interval < 5) {
       interval = 5
     }
-    Memer.log(interval)
+
     if (interval % 5 !== 0) {
       return 'You need to provide an interval that is a multiple of 5 (ie. `5`, `10`, `25`)'
     }

--- a/src/commands/configCommands/automeme.js
+++ b/src/commands/configCommands/automeme.js
@@ -13,15 +13,20 @@ module.exports = new GenericCommand(
     if (!channel) {
       return 'come on you gotta give me a channel name or id to autopost memes to'
     }
-    let interval = Number(msg.args.gather())
-    if (!interval || !Number.isInteger(interval) || Number.isNaN(interval)) {
-      interval = 5
-    }
 
     let check = await Memer.db.getAutomemeChannel(msg.channel.guild.id)
     if (check.channel === channel.id) {
       await Memer.db.removeAutomemeChannel(msg.channel.guild.id)
       return `I'll no longer autopost memes in <#${channel.id}>.`
+    }
+
+    let interval = Number(msg.args.gather())
+    if (!interval || !Number.isInteger(interval) || Number.isNaN(interval) || interval < 5) {
+      interval = 5
+    }
+    Memer.log(interval)
+    if (interval % 5 !== 0) {
+      return 'You need to provide an interval that is a multiple of 5 (ie. `5`, `10`, `25`)'
     }
     await Memer.db.addAutomemeChannel(msg.channel.guild.id, channel.id, interval)
     await addCD()

--- a/src/commands/configCommands/automeme.js
+++ b/src/commands/configCommands/automeme.js
@@ -13,7 +13,10 @@ module.exports = new GenericCommand(
     if (!channel) {
       return 'come on you gotta give me a channel name or id to autopost memes to'
     }
-    let interval = Number(msg.args.gather()) || 5
+    let interval = Number(msg.args.gather())
+    if (!interval || !Number.isInteger(interval) || Number.isNaN(interval)) {
+      interval = 5
+    }
     Memer.log(interval)
 
     let check = await Memer.db.getAutomemeChannel(msg.channel.guild.id)

--- a/src/commands/configCommands/autonsfw.js
+++ b/src/commands/configCommands/autonsfw.js
@@ -36,7 +36,7 @@ module.exports = new GenericCommand(
     if (!interval || !Number.isInteger(interval) || Number.isNaN(interval) || interval < 5) {
       interval = 5
     }
-    if (interval % 5 === 0) {
+    if (interval % 5 !== 0) {
       return 'You need to provide an interval that is a multiple of 5 (ie. `5`, `10`, `25`)'
     }
     await Memer.db.addAutonsfwChannel(msg.channel.guild.id, channel.id, interval, translation[type] || type)

--- a/src/commands/configCommands/autonsfw.js
+++ b/src/commands/configCommands/autonsfw.js
@@ -33,8 +33,11 @@ module.exports = new GenericCommand(
     }
 
     let interval = Number(msg.args.nextArgument())
-    if (!interval || !Number.isInteger(interval) || Number.isNaN(interval)) {
+    if (!interval || !Number.isInteger(interval) || Number.isNaN(interval) || interval < 5) {
       interval = 5
+    }
+    if (interval % 5 === 0) {
+      return 'You need to provide an interval that is a multiple of 5 (ie. `5`, `10`, `25`)'
     }
     await Memer.db.addAutonsfwChannel(msg.channel.guild.id, channel.id, interval, translation[type] || type)
     await addCD()

--- a/src/commands/configCommands/autonsfw.js
+++ b/src/commands/configCommands/autonsfw.js
@@ -16,7 +16,6 @@ module.exports = new GenericCommand(
     if (!channel.nsfw) {
       return 'You can\'t post NSFW content in a non-NSFW marked channel!'
     }
-    let interval = Number(msg.args.gather()) || 5
 
     let check = await Memer.db.getAutonsfwChannel(msg.channel.guild.id)
     if (check.channel === channel.id) {
@@ -24,7 +23,7 @@ module.exports = new GenericCommand(
       return `I'll no longer autopost NSFW content in <#${channel.id}>.`
     }
 
-    let type = msg.args.gather()
+    let type = msg.args.nextArgument()
     if (!['4k', 'boobs', 'ass', 'lesbian', 'gif'].includes(type.toLowerCase())) {
       return `You need to provide a valid porn category for me to post to <#${channel.id}>.\nYou can pick from \`4k\`, \`boobs\`, \`ass\`, \`lesbian\` or \`gif\`\nFor example: \`pls autonsfw #${channel.name} 4k\``
     }
@@ -33,6 +32,10 @@ module.exports = new GenericCommand(
       'gif': 'Gifs'
     }
 
+    let interval = Number(msg.args.nextArgument())
+    if (!interval || !Number.isInteger(interval) || Number.isNaN(interval)) {
+      interval = 5
+    }
     await Memer.db.addAutonsfwChannel(msg.channel.guild.id, channel.id, interval, translation[type] || type)
     await addCD()
 

--- a/src/commands/configCommands/autonsfw.js
+++ b/src/commands/configCommands/autonsfw.js
@@ -16,6 +16,7 @@ module.exports = new GenericCommand(
     if (!channel.nsfw) {
       return 'You can\'t post NSFW content in a non-NSFW marked channel!'
     }
+    let interval = Number(msg.args.gather()) || 5
 
     let check = await Memer.db.getAutonsfwChannel(msg.channel.guild.id)
     if (check.channel === channel.id) {
@@ -32,13 +33,16 @@ module.exports = new GenericCommand(
       'gif': 'Gifs'
     }
 
-    await Memer.db.addAutonsfwChannel(msg.channel.guild.id, channel.id, translation[type] || type)
+    await Memer.db.addAutonsfwChannel(msg.channel.guild.id, channel.id, interval, translation[type] || type)
     await addCD()
 
-    return check ? `Changed autonsfw channel from <#${check.channel}> to **<#${channel.id}>**` : `<#${channel.id}> will now post NSFW content (\`${type}\`) every 5 minutes`
+    return check ? `Changed autonsfw channel from <#${check.channel}> to **<#${channel.id}>**` : `<#${channel.id}> will now post NSFW content (\`${type}\`) every **${interval} minutes**`
   },
   {
     triggers: ['autonsfw'],
+    usage: '{command} [channel] [type] [interval in minutes]',
+    cooldown: 1e4,
+    donorBlocked: true,
     description: 'Set up a channel to automatically post porn to'
   }
 )

--- a/src/utils/Autopost.js
+++ b/src/utils/Autopost.js
@@ -32,10 +32,12 @@ module.exports = class Autopost {
       return this.automeme()
     }
     for (const { channel, id, interval } of check) {
-      const autopostInterval = await this.client.redis.get(`automeme-${id}`)
+      let autopostInterval = await this.client.redis.get(`automeme-${id}`)
         .then(res => res ? JSON.parse(res) : undefined)
       if (!autopostInterval) {
         await this.client.redis.set(`automeme-${id}`, JSON.stringify({ guildID: id, interval: interval || 5, elapsed: 0 }))
+        autopostInterval = await this.client.redis.get(`automeme-${id}`)
+          .then(res => res ? JSON.parse(res) : undefined)
       }
       await this.client.redis.set(`automeme-${id}`, JSON.stringify({ guildID: id, interval: interval || 5, elapsed: Number(autopostInterval.elapsed += 5) }))
       if (autopostInterval.elapsed < autopostInterval.interval) {
@@ -43,7 +45,7 @@ module.exports = class Autopost {
       } else {
         await this.client.redis.set(`automeme-${id}`, JSON.stringify({ guildID: id, interval: interval || 5, elapsed: 0 }))
       }
-   
+
       this.client.bot.createChannelWebhook(channel, {
         name: 'Automeme',
         avatar: this.client.bot.user.dynamicAvatarURL('png')
@@ -73,10 +75,12 @@ module.exports = class Autopost {
   async autonsfw () {
     let check = await this.client.db.allAutonsfwChannels()
     for (const { channel, type, id, interval } of check) {
-      const autopostInterval = await this.client.redis.get(`autonsfw-${id}`)
+      let autopostInterval = await this.client.redis.get(`autonsfw-${id}`)
         .then(res => res ? JSON.parse(res) : undefined)
       if (!autopostInterval) {
         await this.client.redis.set(`autonsfw-${id}`, JSON.stringify({ guildID: id, interval: interval || 5, elapsed: 0 }))
+        autopostInterval = await this.client.redis.get(`autonsfw-${id}`)
+          .then(res => res ? JSON.parse(res) : undefined)
       }
       await this.client.redis.set(`autonsfw-${id}`, JSON.stringify({ guildID: id, interval: interval || 5, elapsed: Number(autopostInterval.elapsed += 5) }))
       if (autopostInterval.elapsed < autopostInterval.interval) {

--- a/src/utils/dbFunctions.js
+++ b/src/utils/dbFunctions.js
@@ -503,9 +503,9 @@ module.exports = Bot => ({
       .run()
   },
 
-  addAutomemeChannel: async function addAutomemeChannel (id, channelID) { // id = guild ID
+  addAutomemeChannel: async function addAutomemeChannel (id, channelID, interval) { // id = guild ID
     return Bot.r.table('automeme')
-      .insert({id: id, channel: channelID})
+      .insert({id: id, channel: channelID, interval})
   },
 
   getAutonsfwChannel: async function getAutonsfwChannel (id) {
@@ -527,9 +527,9 @@ module.exports = Bot => ({
       .run()
   },
 
-  addAutonsfwChannel: async function addAutonsfwChannel (id, channelID, type) { // id = guild ID
+  addAutonsfwChannel: async function addAutonsfwChannel (id, channelID, interval, type) { // id = guild ID
     return Bot.r.table('autonsfw')
-      .insert({id, channel: channelID, type}, { conflict: 'update' })
+      .insert({id, channel: channelID, interval, type}, { conflict: 'update' })
       .run()
   }
 })


### PR DESCRIPTION
This PR introduces the ability to choose the amount of time between posts on autoposting commands.

`automeme` and `autonsfw` have been updated to reflect this change, and the interval will default to **5** if none is provided. Users can only choose an interval that is a multiple of 5, and they can't go below 5.

For existing guilds using autoposting, nothing should be affected. The system will automatically add them to Redis, and everything will be handled from there on out. In the worst case scenario, the first post would fail, but consequential posts would work.

There is one slight flaw in this system; changes probably won't be immediately reflected if somebody changed the interval for a channel. I believe this is because Redis doesn't update the values immediately, instead it just gets the previous ones. **This should fix itself after one successful autopost, however.** I found it was hard to rectify, but if anyone has any ideas on how to fix it, please feel free to let me know 😃