### PR TITLE
Give donors perks to users on premium servers of 20$+ donors

### DIFF
--- a/src/commands/currencyCommands/gamble.js
+++ b/src/commands/currencyCommands/gamble.js
@@ -1,11 +1,11 @@
 const GenericCommand = require('../../models/GenericCommand')
 
 module.exports = new GenericCommand(
-  async ({ Memer, msg, addCD }) => {
+  async ({ Memer, msg, addCD, isGlobalPremiumGuild }) => {
     let user = msg.author
     let userDB = await Memer.db.getUser(user.id)
     let donor = await Memer.db.checkDonor(user.id)
-    let multi = await Memer.calcMultiplier(Memer, user, userDB, donor, msg)
+    let multi = await Memer.calcMultiplier(Memer, user, userDB, donor, msg, isGlobalPremiumGuild)
     let coins = userDB.pocket
 
     let bet = msg.args.args[0]

--- a/src/commands/currencyCommands/multiplier.js
+++ b/src/commands/currencyCommands/multiplier.js
@@ -1,12 +1,12 @@
 const GenericCommand = require('../../models/GenericCommand')
 
 module.exports = new GenericCommand(
-  async ({ Memer, msg, addCD }) => {
+  async ({ Memer, msg, addCD, isGlobalPremiumGuild }) => {
     let user = msg.author
     let userDB = await Memer.db.getUser(user.id)
     let donor = await Memer.db.checkDonor(user.id)
-    let total = await Memer.calcMultiplier(Memer, user, userDB, donor, msg)
-    let show = await Memer.showMultiplier(Memer, user, userDB, donor, msg)
+    let total = await Memer.calcMultiplier(Memer, user, userDB, donor, msg, isGlobalPremiumGuild)
+    let show = await Memer.showMultiplier(Memer, user, userDB, donor, msg, isGlobalPremiumGuild)
     await addCD()
     return {
       title: `Here is some info about your Multipliers, ${user.username}`,

--- a/src/handlers/messageCreate.js
+++ b/src/handlers/messageCreate.js
@@ -91,6 +91,7 @@ exports.handle = async function (msg) {
   }
 
   let isDonor = await this.db.checkDonor(msg.author.id)
+  const isGlobalPremiumGuild = await this.db.checkGlobalPremiumGuild(msg.channel.guild.id)
 
   const selfMember = msg.channel.guild.members.get(this.bot.user.id)
   const mention = `<@${selfMember.nick ? '!' : ''}${selfMember.id}>`
@@ -123,7 +124,7 @@ exports.handle = async function (msg) {
     ((gConfig.disabledCategories || []).includes(command.category.split(' ')[1].toLowerCase()) && !['disable', 'enable'].includes(command.props.triggers[0]) && !gConfig.enabledCommands.includes(command.props.triggers[0]))
   ) {
     return
-  } else if (command.props.donorOnly && !isDonor && !this.config.options.developers.includes(msg.author.id)) {
+  } else if (command.props.donorOnly && !isDonor && (!isGlobalPremiumGuild || command.props.triggers.includes('redeem')) && !this.config.options.developers.includes(msg.author.id)) {
     return msg.channel.createMessage('This command is for donors only. You can find more information by using `pls donate` if you are interested.')
   }
 
@@ -142,7 +143,7 @@ exports.handle = async function (msg) {
   const isInCooldown = await checkCooldowns.bind(this)(msg, command, isDonor)
   if (isInCooldown) { return }
 
-  const updateCooldowns = () => this.db.updateCooldowns(command.props.triggers[0], msg.author.id)
+  const updateCooldowns = () => this.db.updateCooldowns(command.props.triggers[0], msg.author.id, isGlobalPremiumGuild)
 
   try {
     const permissions = msg.channel.permissionsOf(this.bot.user.id)
@@ -163,7 +164,7 @@ exports.handle = async function (msg) {
       )
     } else {
       msg.reply = (str) => { msg.channel.createMessage(`${msg.author.mention}, ${str}`) }
-      await runCommand.bind(this)(command, msg, args, cleanArgs, updateCooldowns)
+      await runCommand.bind(this)(command, msg, args, cleanArgs, updateCooldowns, isGlobalPremiumGuild)
     }
   } catch (e) {
     reportError.bind(this)(e, msg, command, cleanArgs)
@@ -171,7 +172,7 @@ exports.handle = async function (msg) {
 }
 
 function cacheMessage (msg) {
-  if (!msg.content) { // Ignroe attachments without content
+  if (!msg.content) { // Ignore attachments without content
     return
   }
   this.redis.set(`msg-${msg.id}`, JSON.stringify({ userID: msg.author.id, content: msg.content, timestamp: msg.timestamp, guildID: msg.channel.guild.id, channelID: msg.channel.id }), 'EX', 20 * 60)
@@ -239,14 +240,15 @@ function checkPerms (command, permissions, msg) {
   }
 }
 
-async function runCommand (command, msg, args, cleanArgs, updateCooldowns) {
+async function runCommand (command, msg, args, cleanArgs, updateCooldowns, isGlobalPremiumGuild) {
   this.stats.commands++
   let res = await command.run({
     msg,
     args,
     cleanArgs,
     Memer: this,
-    addCD: updateCooldowns
+    addCD: updateCooldowns,
+    isGlobalPremiumGuild
   })
   if (!res) {
     return

--- a/src/models/GenericCommand.js
+++ b/src/models/GenericCommand.js
@@ -59,6 +59,7 @@
  * @prop {MemerMessage} msg The message
  * @prop {Array<String>} args The raw sliced arguments
  * @prop {Array<String>} cleanArgs The raw sliced arguments, but with mentions nullified
+ * @prop {Boolean} isGlobalPremiumGuild Whether this guild is a premium guild redeemed by a 20$+ donator
  */
 
 module.exports = class GenericCommand {
@@ -72,7 +73,7 @@ module.exports = class GenericCommand {
     this.cmdProps = props
   }
 
-  async run ({ Memer, msg, args, addCD, cleanArgs }) {
+  async run ({ Memer, msg, args, addCD, cleanArgs, isGlobalPremiumGuild }) {
     if (this.props.missingArgs && !args[0]) {
       return this.props.missingArgs
     }
@@ -82,7 +83,7 @@ module.exports = class GenericCommand {
     if (this.props.requiresPremium && !await Memer.db.checkPremiumGuild(msg.channel.guild.id)) {
       return 'This command is only available on **Premium** servers.\nTo learn more about how to redeem a premium server, visit our Patreon https://www.patreon.com/dankmemerbot'
     }
-    return this.fn({ Memer, msg, args, addCD, cleanArgs })
+    return this.fn({ Memer, msg, args, addCD, cleanArgs, isGlobalPremiumGuild })
   }
 
   get props () {

--- a/src/models/GenericModerationCommand.js
+++ b/src/models/GenericModerationCommand.js
@@ -13,7 +13,7 @@ module.exports = class GenericModerationCommand {
     this.cmdProps = cmdProps
   }
 
-  async run ({ Memer, msg, args, addCD, cleanArgs }) {
+  async run ({ Memer, msg, args, addCD, cleanArgs, isGlobalPremiumGuild }) {
     // modPerms will be an array of permissions that are required by the user to run this command
     // If no permissions are passed, this code is never considered.
     for (const requiredPermission of this.cmdProps.perms || []) {
@@ -33,7 +33,7 @@ module.exports = class GenericModerationCommand {
     }
 
     await addCD()
-    return this.fn({ Memer, msg, args, addCD, cleanArgs })
+    return this.fn({ Memer, msg, args, addCD, cleanArgs, isGlobalPremiumGuild })
   }
 
   missingPermission (type, permission) {

--- a/src/models/GenericMusicCommand.js
+++ b/src/models/GenericMusicCommand.js
@@ -21,7 +21,7 @@ module.exports = class GenericMusicCommand {
     this.cmdProps = cmdProps
   }
 
-  async run ({ Memer, msg, addCD, args, cleanArgs }) {
+  async run ({ Memer, msg, addCD, args, cleanArgs, isGlobalPremiumGuild }) {
     if (this.props.requiresPremium && !await Memer.db.checkPremiumGuild(msg.channel.guild.id)) {
       return 'This command is only available on **Premium** servers.\nTo learn more about how to redeem a premium server, visit our Patreon https://www.patreon.com/dankmemerbot'
     }
@@ -39,7 +39,7 @@ module.exports = class GenericMusicCommand {
     await music.ready
     music.channel = msg.channel.id
 
-    return this.fn({ Memer, msg, args, addCD, cleanArgs, music })
+    return this.fn({ Memer, msg, args, addCD, cleanArgs, isGlobalPremiumGuild, music })
   }
 
   get props () {

--- a/src/utils/dbFunctions.js
+++ b/src/utils/dbFunctions.js
@@ -77,12 +77,12 @@ module.exports = Bot => ({
       .run()
   },
 
-  updateCooldowns: async function createCooldown (command, ownerID) {
+  updateCooldowns: async function createCooldown (command, ownerID, isGlobalPremiumGuild) {
     const pCommand = Bot.cmds.find(c => c.props.triggers.includes(command.toLowerCase()))
     if (!pCommand) {
       return
     }
-    const isDonor = await this.checkDonor(ownerID)
+    const isDonor = isGlobalPremiumGuild || await this.checkDonor(ownerID)
     let cooldown
     if (isDonor && !pCommand.props.donorBlocked) {
       cooldown = pCommand.props.donorCD
@@ -452,6 +452,13 @@ module.exports = Bot => ({
       .get(id)('donorAmount')
       .default(false)
       .run()
+  },
+
+  checkGlobalPremiumGuild: function checkGlobalPremiumServer (id) {
+    return Bot.r.table('donors')
+      .filter(Bot.r.row('guilds').contains(id))
+      .run()
+      .then(results => results[0] && results[0].donorAmount >= 20)
   },
 
   getStats: function getStats () {

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -82,7 +82,7 @@ module.exports = {
    * @param {Message} msg The message
    * @returns {Number} The total multiplier for this user
    */
-  calcMultiplier (Memer, user, userDB, donor, msg) {
+  calcMultiplier (Memer, user, userDB, donor, msg, isGlobalPremiumGuild) {
     // calculates total multiplier based on multiple variables
     let guildMember = msg.channel.guild.members.get(msg.author.id)
     let date = new Date(msg.timestamp)
@@ -114,8 +114,8 @@ module.exports = {
     if (msg.channel.guild.members.has('419254454169108480')) {
       total += 0.5
     }
-    if (donor) {
-      total += donor * 0.5
+    if (donor || isGlobalPremiumGuild) {
+      total += (donor || 20) * 0.5
     }
     if (userDB.spam < 25) {
       total += 0.5
@@ -152,7 +152,7 @@ module.exports = {
    * @param {Message} msg The message
    * @returns {String} A list of all the active multipliers for this user
    */
-  showMultiplier (Memer, user, userDB, donor, msg) {
+  showMultiplier (Memer, user, userDB, donor, msg, isGlobalPremiumGuild) {
     // calculates total multiplier based on multiple variables
     let guildMember = msg.channel.guild.members.get(msg.author.id)
     let date = new Date(msg.timestamp)
@@ -195,6 +195,9 @@ module.exports = {
     if (donor) {
       end.unlocked.total += 1
       end.unlocked.list.push('[Donor](https://www.patreon.com/dankmemerbot)')
+    } else if (isGlobalPremiumGuild) {
+      end.unlocked.total += 1
+      end.unlocked.list.push('On a premium guild redeemed by a 20$+ [donor](https://www.patreon.com/dankmemerbot)')
     }
     if (userDB.spam < 25) {
       end.unlocked.total += 1


### PR DESCRIPTION
This PR gives most donor perks to all users on premium servers redeemed by a 20$+ donor

(As in: All donor commands (except redeem), gambling multiplier and donor cooldowns)

Realized on the way that gamble system (multipliers and all) is entirely broken OR way too random (the code is wayyy too confusing so i can't even say if it's actually broken) but that's outside the scope of this PR  