### PR TITLE
GenericVoiceCommand upgrades

### DIFF
--- a/src/handlers/voiceChannelLeave.js
+++ b/src/handlers/voiceChannelLeave.js
@@ -1,0 +1,8 @@
+exports.handle = async function (member, oldChannel) {
+  if (member) {
+    const music = this.musicManager.get(member.guild.id)
+    if (music.sfxautoplay.enabled && music.sfxautoplay.host === member) {
+      await music.endSession()
+    }
+  }
+}

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -13,7 +13,21 @@ module.exports = class GenericVoiceCommand {
     const music = Memer.musicManager.get(msg.channel.guild.id)
 
     let response = await music.node.load(encodeURIComponent(`${Memer.config.links.youtube[this.cmdProps.dir]}`))
-    const { tracks } = response
+    let { tracks } = response
+
+    if (args.length) {
+      // Repeat function
+      let donor = await Memer.db.checkDonor(msg.author.id)
+      if ((args.includes('-autoplay') || args.includes('-repeat')) && donor) {
+        music.sfxautoplay = true
+      } else {
+        // Search
+        tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track)
+        if (!tracks.length) {
+          return 'your search returned no results damn'
+        }
+      }
+    }
     if (!tracks[0]) {
       return 'Seems like this didn\'t work, sad.'
     }

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -20,11 +20,16 @@ module.exports = class GenericVoiceCommand {
 
     let { tracks } = response
 
+    if (music.sfxautoplay.enabled && msg.member !== music.sfxautoplay.host) {
+      return `You can't play any sound effects right now because **${music.sfxautoplay.host.user.username}** has started a \`mememusic\` autoplay session. Meme music will continuously play until the host leaves, or someone stops the music using \`pls stop\``
+    }
+
     if (args.length) {
       // Repeat function
       let donor = await Memer.db.checkDonor(msg.author.id)
       if ((args.includes('-autoplay') || args.includes('-repeat')) && donor) {
-        music.sfxautoplay = { enabled: true, host: msg.member }
+        music.sfxautoplay = { enabled: !music.sfxautoplay.enabled, host: msg.member }
+        msg.channel.createMessage('nice, meme music will keep playing until you leave the channel or stop the music\nYou can also use `pls mememusic -autoplay` again to turn this off')
       } else {
         // Search
         tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track)
@@ -33,6 +38,7 @@ module.exports = class GenericVoiceCommand {
         }
       }
     }
+
     if (!tracks[0]) {
       return 'Seems like this didn\'t work, sad.'
     }

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -10,44 +10,44 @@ module.exports = class GenericVoiceCommand {
   }
 
   async run ({ Memer, msg, args, addCD }) {
-    const music = Memer.musicManager.get(msg.channel.guild.id)
+    const music = Memer.musicManager.get(msg.channel.guild.id);
     let response = await Memer.redis.get(`cachedplaylist-${this.cmdProps.dir}`)
-      .then(res => res ? JSON.parse(res) : undefined)
+      .then(res => res ? JSON.parse(res) : undefined);
     if (!response) {
-      response = await music.node.load(encodeURIComponent(`${Memer.config.links.youtube[this.cmdProps.dir]}`))
-      Memer.redis.set(`cachedplaylist-${this.cmdProps.dir}`, JSON.stringify(response))
+      response = await music.node.load(encodeURIComponent(`${Memer.config.links.youtube[this.cmdProps.dir]}`));
+      Memer.redis.set(`cachedplaylist-${this.cmdProps.dir}`, JSON.stringify(response));
     }
 
-    let { tracks } = response
+    let { tracks } = response;
 
     if (!tracks[0]) {
       return 'Seems like this didn\'t work, sad.';
     }
 
     if (args.includes('-list')) {
-      return `You can find a list of all the songs used in \`${this.props.triggers[0]}\` here:\n${Memer.config.links.youtube[this.cmdProps.dir]}`
+      return `You can find a list of all the songs used in \`${this.props.triggers[0]}\` here:\n${Memer.config.links.youtube[this.cmdProps.dir]}`;
     }
 
     if (music.sfxautoplay.enabled && msg.member !== music.sfxautoplay.host) {
-      return `You can't play anything right now because **${music.sfxautoplay.host.user.username}** has started a \`${music.sfxautoplay.name}\` autoplay session. Tracks from \`${music.sfxautoplay.name}\` will continuously play until the host leaves, or someone stops the music using \`pls stop\``
+      return `You can't play anything right now because **${music.sfxautoplay.host.user.username}** has started a \`${music.sfxautoplay.name}\` autoplay session. Tracks from \`${music.sfxautoplay.name}\` will continuously play until the host leaves, or someone stops the music using \`pls stop\``;
     }
 
     if (args.length) {
       // Repeat function
-      let donor = await Memer.db.checkDonor(msg.author.id)
+      let donor = await Memer.db.checkDonor(msg.author.id);
       if ((args.includes('-autoplay') || args.includes('-repeat')) && donor) {
-        music.sfxautoplay = { enabled: !music.sfxautoplay.enabled, host: msg.member, type: this.cmdProps.dir, name: this.props.triggers[0] }
-        msg.channel.createMessage(`nice, ${this.props.triggers[0]} songs will keep playing until you leave the channel or stop the music\nYou can also use \`pls ${this.props.triggers[0]} -autoplay\` again to turn this off`)
+        music.sfxautoplay = { enabled: !music.sfxautoplay.enabled, host: msg.member, type: this.cmdProps.dir, name: this.props.triggers[0] };
+        msg.channel.createMessage(`nice, ${this.props.triggers[0]} songs will keep playing until you leave the channel or stop the music\nYou can also use \`pls ${this.props.triggers[0]} -autoplay\` again to turn this off`);
       } else {
         // Search
-        tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track)
+        tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track);
         if (!tracks.length) {
-          return 'your search returned no results damn'
+          return 'your search returned no results damn';
         }
       }
     }
 
-    const song = Memer.randomInArray(tracks)
+    const song = Memer.randomInArray(tracks);
 
     if (this.cmdProps.soundboard) {
       if (args.length === 0) {
@@ -89,9 +89,9 @@ module.exports = class GenericVoiceCommand {
       msg.addReaction(this.cmdProps.reaction);
     }
 
-    await music.player.join(msg.member.voiceState.channelID)
-    music.channel = msg.channel.id
-    await music.ready
+    await music.player.join(msg.member.voiceState.channelID);
+    music.channel = msg.channel.id;
+    await music.ready;
     if (music.queue[0]) {
       music.queue = [];
     }

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -21,7 +21,7 @@ module.exports = class GenericVoiceCommand {
     let { tracks } = response
 
     if (music.sfxautoplay.enabled && msg.member !== music.sfxautoplay.host) {
-      return `You can't play any sound effects right now because **${music.sfxautoplay.host.user.username}** has started a \`mememusic\` autoplay session. Meme music will continuously play until the host leaves, or someone stops the music using \`pls stop\``
+      return `You can't play anything right now because **${music.sfxautoplay.host.user.username}** has started a \`${this.props.triggers[0]}\` autoplay session. Tracks from \`${this.props.triggers[0]}\` will continuously play until the host leaves, or someone stops the music using \`pls stop\``
     }
 
     if (args.length) {
@@ -30,6 +30,8 @@ module.exports = class GenericVoiceCommand {
       if ((args.includes('-autoplay') || args.includes('-repeat')) && donor) {
         music.sfxautoplay = { enabled: !music.sfxautoplay.enabled, host: msg.member }
         msg.channel.createMessage('nice, meme music will keep playing until you leave the channel or stop the music\nYou can also use `pls mememusic -autoplay` again to turn this off')
+      } else if (args.includes('-list')) {
+        return `You can find a list of all the songs used in \`${this.props.triggers[0]}\` here:\n${Memer.config.links.youtube[this.cmdProps.dir]}`
       } else {
         // Search
         tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track)
@@ -85,6 +87,7 @@ module.exports = class GenericVoiceCommand {
     }
 
     await music.player.join(msg.member.voiceState.channelID)
+    music.channel = msg.channel.id
     await music.ready
     if (music.queue[0]) {
       music.queue = []

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -37,7 +37,7 @@ module.exports = class GenericVoiceCommand {
       let donor = await Memer.db.checkDonor(msg.author.id)
       if ((args.includes('-autoplay') || args.includes('-repeat')) && donor) {
         music.sfxautoplay = { enabled: !music.sfxautoplay.enabled, host: msg.member, type: this.cmdProps.dir, name: this.props.triggers[0] }
-        msg.channel.createMessage('nice, meme music will keep playing until you leave the channel or stop the music\nYou can also use `pls mememusic -autoplay` again to turn this off')
+        msg.channel.createMessage(`nice, ${this.props.triggers[0]} songs will keep playing until you leave the channel or stop the music\nYou can also use \`pls ${this.props.triggers[0]} -autoplay\` again to turn this off`)
       } else {
         // Search
         tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track)

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -24,7 +24,7 @@ module.exports = class GenericVoiceCommand {
       // Repeat function
       let donor = await Memer.db.checkDonor(msg.author.id)
       if ((args.includes('-autoplay') || args.includes('-repeat')) && donor) {
-        music.sfxautoplay = true
+        music.sfxautoplay = { enabled: true, host: msg.member }
       } else {
         // Search
         tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track)

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -20,18 +20,24 @@ module.exports = class GenericVoiceCommand {
 
     let { tracks } = response
 
+    if (!tracks[0]) {
+      return 'Seems like this didn\'t work, sad.'
+    }
+
+    if (args.includes('-list')) {
+      return `You can find a list of all the songs used in \`${this.props.triggers[0]}\` here:\n${Memer.config.links.youtube[this.cmdProps.dir]}`
+    }
+
     if (music.sfxautoplay.enabled && msg.member !== music.sfxautoplay.host) {
-      return `You can't play anything right now because **${music.sfxautoplay.host.user.username}** has started a \`${this.props.triggers[0]}\` autoplay session. Tracks from \`${this.props.triggers[0]}\` will continuously play until the host leaves, or someone stops the music using \`pls stop\``
+      return `You can't play anything right now because **${music.sfxautoplay.host.user.username}** has started a \`${music.sfxautoplay.name}\` autoplay session. Tracks from \`${music.sfxautoplay.name}\` will continuously play until the host leaves, or someone stops the music using \`pls stop\``
     }
 
     if (args.length) {
       // Repeat function
       let donor = await Memer.db.checkDonor(msg.author.id)
       if ((args.includes('-autoplay') || args.includes('-repeat')) && donor) {
-        music.sfxautoplay = { enabled: !music.sfxautoplay.enabled, host: msg.member }
+        music.sfxautoplay = { enabled: !music.sfxautoplay.enabled, host: msg.member, type: this.cmdProps.dir, name: this.props.triggers[0] }
         msg.channel.createMessage('nice, meme music will keep playing until you leave the channel or stop the music\nYou can also use `pls mememusic -autoplay` again to turn this off')
-      } else if (args.includes('-list')) {
-        return `You can find a list of all the songs used in \`${this.props.triggers[0]}\` here:\n${Memer.config.links.youtube[this.cmdProps.dir]}`
       } else {
         // Search
         tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track)
@@ -41,9 +47,6 @@ module.exports = class GenericVoiceCommand {
       }
     }
 
-    if (!tracks[0]) {
-      return 'Seems like this didn\'t work, sad.'
-    }
     const song = Memer.randomInArray(tracks)
 
     if (this.cmdProps.soundboard) {

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -11,8 +11,13 @@ module.exports = class GenericVoiceCommand {
 
   async run ({ Memer, msg, args, addCD }) {
     const music = Memer.musicManager.get(msg.channel.guild.id)
+    let response = await Memer.redis.get(`cachedplaylist-${this.cmdProps.dir}`)
+      .then(res => res ? JSON.parse(res) : undefined)
+    if (!response) {
+      response = await music.node.load(encodeURIComponent(`${Memer.config.links.youtube[this.cmdProps.dir]}`))
+      Memer.redis.set(`cachedplaylist-${this.cmdProps.dir}`, JSON.stringify(response))
+    }
 
-    let response = await music.node.load(encodeURIComponent(`${Memer.config.links.youtube[this.cmdProps.dir]}`))
     let { tracks } = response
 
     if (args.length) {

--- a/src/models/GenericVoiceCommand.js
+++ b/src/models/GenericVoiceCommand.js
@@ -43,7 +43,7 @@ module.exports = class GenericVoiceCommand {
         await Memer.sleep(100);
         await music.player.join(msg.member.voiceState.channelID);
         await music._play();
-        return `nice, ${this.props.triggers[0]} songs will keep playing until you leave the channel or stop the music\nYou can also use \`pls ${this.props.triggers[0]} -autoplay\` again to turn this off`;
+        return `nice, ${this.props.triggers[0]} songs will keep playing until you leave the channel or stop the music\nYou can also just use \`pls ${this.props.triggers[0]}\` again to turn this off`;
       } else {
         // Search
         tracks = tracks.filter(track => track.info ? track.info.title.toLowerCase().includes(args.join(' ').toLowerCase()) : track);

--- a/src/models/Music.js
+++ b/src/models/Music.js
@@ -22,9 +22,9 @@ module.exports = class Music {
     /** @type {String} */
     this._channelID = null;
     /** @type {Promise|Boolean} Whether the player is ready */
-    this.ready = this._loadQueue()
-    this.vote = null
-    this.sfxautoplay = { enabled: false, host: null, type: null, name: null }
+    this.ready = this._loadQueue();
+    this.vote = null;
+    this.sfxautoplay = { enabled: false, host: null, type: null, name: null };
   }
 
   /**
@@ -195,14 +195,14 @@ module.exports = class Music {
     if (this.sfxautoplay.enabled) {
       return (async () => {
         let response = await this.client.redis.get(`cachedplaylist-${this.sfxautoplay.type}`)
-          .then(res => res ? JSON.parse(res) : undefined)
+          .then(res => res ? JSON.parse(res) : undefined);
         if (response) {
-          let { tracks } = response
-          const song = this.client.randomInArray(tracks)
-          this.addSong(song, true)
-          return this._play()
+          let { tracks } = response;
+          const song = this.client.randomInArray(tracks);
+          this.addSong(song, true);
+          return this._play();
         }
-      })()
+      })();
     }
     if (this.vote) {
       this.resetVote();

--- a/src/models/Music.js
+++ b/src/models/Music.js
@@ -24,6 +24,7 @@ module.exports = class Music {
     /** @type {Promise|Boolean} Whether the player is ready */
     this.ready = this._loadQueue()
     this.vote = null
+    this.sfxautoplay = false
   }
 
   /**

--- a/src/models/Music.js
+++ b/src/models/Music.js
@@ -192,6 +192,18 @@ module.exports = class Music {
   }
 
   _finished (event, shifted) {
+    if (this.sfxautoplay) {
+      return (async () => {
+        let response = await this.client.redis.get(`cachedplaylist-shitsound`)
+          .then(res => res ? JSON.parse(res) : undefined)
+        if (response) {
+          let { tracks } = response
+          const song = this.client.randomInArray(tracks)
+          this.addSong(song, true)
+          return this._play()
+        }
+      })()
+    }
     if (this.vote) {
       this.resetVote()
       this._send(`The vote to skip the song \`${shifted.info.title}\` has been cancelled because the song just ended`)

--- a/src/models/Music.js
+++ b/src/models/Music.js
@@ -24,7 +24,7 @@ module.exports = class Music {
     /** @type {Promise|Boolean} Whether the player is ready */
     this.ready = this._loadQueue()
     this.vote = null
-    this.sfxautoplay = { enabled: false, host: null }
+    this.sfxautoplay = { enabled: false, host: null, type: null, name: null }
   }
 
   /**
@@ -194,7 +194,7 @@ module.exports = class Music {
   _finished (event, shifted) {
     if (this.sfxautoplay.enabled) {
       return (async () => {
-        let response = await this.client.redis.get(`cachedplaylist-shitsound`)
+        let response = await this.client.redis.get(`cachedplaylist-${this.sfxautoplay.type}`)
           .then(res => res ? JSON.parse(res) : undefined)
         if (response) {
           let { tracks } = response

--- a/src/models/Music.js
+++ b/src/models/Music.js
@@ -24,7 +24,7 @@ module.exports = class Music {
     /** @type {Promise|Boolean} Whether the player is ready */
     this.ready = this._loadQueue()
     this.vote = null
-    this.sfxautoplay = false
+    this.sfxautoplay = { enabled: false, host: null }
   }
 
   /**
@@ -77,6 +77,9 @@ module.exports = class Music {
     }
     if (this.playing) {
       return this.stop()
+    }
+    if (this.sfxautoplay.enabled) {
+      this.sfxautoplay = { enabled: false, host: null }
     }
   }
 
@@ -192,7 +195,7 @@ module.exports = class Music {
   }
 
   _finished (event, shifted) {
-    if (this.sfxautoplay) {
+    if (this.sfxautoplay.enabled) {
       return (async () => {
         let response = await this.client.redis.get(`cachedplaylist-shitsound`)
           .then(res => res ? JSON.parse(res) : undefined)

--- a/src/models/Music.js
+++ b/src/models/Music.js
@@ -78,9 +78,6 @@ module.exports = class Music {
     if (this.playing) {
       return this.stop()
     }
-    if (this.sfxautoplay.enabled) {
-      this.sfxautoplay = { enabled: false, host: null }
-    }
   }
 
   /**

--- a/src/models/Music.js
+++ b/src/models/Music.js
@@ -33,9 +33,11 @@ module.exports = class Music {
    * @param {Boolean} [unshift=false] Whether to push the song at the front of the queue, defaults to `false`
    * @returns {Promise<void>}
    */
-  addSong (song, unshift) {
+  addSong (song, unshift, index) {
     if (unshift) {
       this.queue.unshift(song);
+    } else if (index > -1) {
+      this.queue.splice(index, 0, song);
     } else {
       this.queue.push(song);
     }
@@ -199,7 +201,7 @@ module.exports = class Music {
         if (response) {
           let { tracks } = response;
           const song = this.client.randomInArray(tracks);
-          this.addSong(song, true);
+          await this.addSong(song, true);
           return this._play();
         }
       })();


### PR DESCRIPTION
This PR implements an `autoplay` flag to all commands under `GenericVoiceCommand` as well as some other major fixes and features.

The idea works like this;
`1.` User runs `pls mememusic -autoplay`
`2.` A randomly selected `mememusic` track plays
`3.` When finished (on `_finished`), randomly select another `mememusic` track to play and play it

This continues until;
`1.` The original user leaves the voice channel
`2.` Somebody runs `pls stop`
`3.` The original user runs another `GenericVoiceCommand` such as `pls mlg`

On top of all of this, all `GenericVoiceCommand` commands now have a search functionality built-in, simply activated by passing your search in the arguments.

`GenericVoiceCommand` commands will automatically override any tracks queued using `pls play`. They will also no longer clear the queue when used. Just as one final cherry on the top since I'm nice like that, these commands will no longer make the bot glitch out and **leave + join** at the same time when playing something. 👍 