### PR TITLE
Improved hot reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dank-memer",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A discord entertainment based bot, with an emphasis on memes.",
   "main": "memer.js",
   "scripts": {
@@ -25,19 +25,21 @@
   "dependencies": {
     "asciiart-logo": "^0.1.7",
     "cheerio": "^1.0.0-rc.2",
-    "eris-sharder": "^1.7.9",
+    "eris-sharder": "github:Discord-Sharders/eris-sharder#dev",
+    "ioredis": "^4.0.0",
+    "lavalink": "^2.2.2",
+    "node-dogstatsd": "0.0.7",
+    "programmatic-repl": "^1.1.4",
+    "rethinkdbdash": "^2.3.31",
+    "semistandard": "^12.0.1",
+    "tubesearch": "^1.0.5"
+  },
+  "devDependencies": {
     "eslint-config-semistandard": "^12.0.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-standard": "^4.0.0",
-    "ioredis": "^4.0.0",
-    "lavalink": "^2.1.1",
-    "node-dogstatsd": "0.0.7",
-    "programmatic-repl": "^1.1.4",
-    "rethinkdbdash": "^2.3.31",
-    "semistandard": "^12.0.1",
-    "standard": "^11.0.1",
-    "tubesearch": "^1.0.5"
+    "@types/node": "^10.11.7"
   }
 }

--- a/src/commands/utilityCommands/dev/commands/reload.js
+++ b/src/commands/utilityCommands/dev/commands/reload.js
@@ -4,7 +4,7 @@ module.exports = {
   help: 'reload [all | commands | config | command [command|all] | category [command category] | models | utils]',
   /** @param {FunctionParams} */
   fn: async ({ Memer, msg, args }) => {
-    if (['category', 'command', 'commands', 'all', 'models', 'events', 'utils'].includes(args[0])) {
+    if (['category', 'command', 'commands', 'all', 'models', 'events', 'utils', 'config'].includes(args[0])) {
       const m = await msg.channel.createMessage(`confirm spicy reload? \`y\`/\`n\``);
 
       const choice = await Memer.MessageCollector.awaitMessage(msg.channel.id, msg.author.id, 5e4);
@@ -21,6 +21,9 @@ module.exports = {
       case 'category':
         try {
           const category = msg.args.nextArgument(false).toLowerCase();
+          if (!category) {
+            return `You gotta specify a category to reload stupid`;
+          }
           Memer.ipc.broadcast('reloadCommands', { category });
           return `Reloaded command category ${category}`;
         } catch (err) {
@@ -50,7 +53,10 @@ module.exports = {
         }
       case 'all':
         try {
-          Memer.ipc.broadcast('reloadAll', {});
+          await msg.channel.createMessage(`Preserve connections to lavalink/redis/rethink...? \`y\`/\`n\``);
+          let choice = await Memer.MessageCollector.awaitMessage(msg.channel.id, msg.author.id, 5e4);
+          choice = (!choice || choice.content.toLowerCase() === 'y');
+          Memer.ipc.broadcast('reloadAll', { preserveConnections: choice });
           return `Reloaded welp everything`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;

--- a/src/commands/utilityCommands/dev/commands/reload.js
+++ b/src/commands/utilityCommands/dev/commands/reload.js
@@ -1,7 +1,10 @@
+/** @typedef {import("../../../../models/GenericCommand").FunctionParams} FunctionParams */
+
 module.exports = {
-  help: 'reload [most | commands | config]',
+  help: 'reload [all | commands | config | command [command|all] | category [command category] | models | utils]',
+  /** @param {FunctionParams} */
   fn: async ({ Memer, msg, args }) => {
-    if (['most', 'commands', 'config'].includes(args[0])) {
+    if (['category', 'command', 'commands', 'all', 'models', 'events', 'utils'].includes(args[0])) {
       const m = await msg.channel.createMessage(`confirm spicy reload? \`y\`/\`n\``);
 
       const choice = await Memer.MessageCollector.awaitMessage(msg.channel.id, msg.author.id, 5e4);
@@ -9,35 +12,70 @@ module.exports = {
         m.edit('whew, dodged a bullet');
         return;
       }
+    } else {
+      return 'reload [all | commands | config | command [command|all] | category [command category] | models | utils]';
     }
 
-    switch (args[0]) {
-      case 'most':
+    const type = msg.args.nextArgument(false).toLowerCase();
+    switch (type) {
+      case 'category':
         try {
-          Memer.ipc.broadcast('reloadMost', {});
-          return 'Successfully reloaded basically everything besides the main class';
+          const category = msg.args.nextArgument(false).toLowerCase();
+          Memer.ipc.broadcast('reloadCommands', { category });
+          return `Reloaded command category ${category}`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
         }
-
+      case 'command':
+        try {
+          const command = msg.args.nextArgument(false).toLowerCase();
+          Memer.ipc.broadcast('reloadCommands', command === 'all' ? {} : { command });
+          return `Reloaded ${command === 'all' ? 'all commands' : (command + ' command')}`;
+        } catch (err) {
+          return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
+        }
+      case 'events':
+        try {
+          Memer.ipc.broadcast('reloadListeners', {});
+          return `Reloaded all event listeners`;
+        } catch (err) {
+          return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
+        }
       case 'commands':
         try {
           Memer.ipc.broadcast('reloadCommands', {});
-          return 'Successfully reloaded all commands!!!!';
+          return `Reloaded all commands`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
         }
-
+      case 'all':
+        try {
+          Memer.ipc.broadcast('reloadAll', {});
+          return `Reloaded welp everything`;
+        } catch (err) {
+          return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
+        }
       case 'config':
         try {
           Memer.ipc.broadcast('reloadConfig', {});
-          return 'Successfully reloaded config file.';
+          return `Reloaded config`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
         }
-
-      default:
-        return '[most | commands | config]';
+      case 'utils':
+        try {
+          Memer.ipc.broadcast('reloadUtils', {});
+          return `Reloaded utils`;
+        } catch (err) {
+          return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
+        }
+      case 'models':
+        try {
+          Memer.ipc.broadcast('reloadModels', {});
+          return `Reloaded models`;
+        } catch (err) {
+          return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
+        }
     }
   }
 };

--- a/src/handlers/messageCreate.js
+++ b/src/handlers/messageCreate.js
@@ -203,7 +203,7 @@ function cacheMessage (msg) {
 
 async function updateStats (msg, command, userEntry) {
   if (!userEntry._saved) {
-    userEntry.save();
+    userEntry.save().catch(() => {});
   }
 }
 

--- a/src/mainClass.js
+++ b/src/mainClass.js
@@ -5,8 +5,8 @@ const { Cluster } = require('lavalink');
 const cluster = require('cluster');
 const { StatsD } = require('node-dogstatsd');
 
-const MessageCollector = require('./utils/MessageCollector.js');
-const botPackage = require('../package.json');
+let MessageCollector = require('./utils/MessageCollector.js');
+let botPackage = require('../package.json');
 
 class Memer extends Base {
   constructor (bot) {
@@ -53,6 +53,7 @@ class Memer extends Base {
       errReported: 0,
       err: 0
     };
+    this.listeners = {};
     this.cooldowns = new Map();
     this._cooldownsSweep = setInterval(this._sweepCooldowns.bind(this), 1000 * 60 * 30);
     // work-around to benefit from nice documentation and still have misc functions assigned on the Memer instance
@@ -71,12 +72,7 @@ class Memer extends Base {
     this.createIPC();
     this.ddog.increment('function.launch');
     this.MessageCollector = new MessageCollector(this.bot);
-    this.bot
-      .on('ready', this.ready.bind(this));
-    const listeners = require(join(__dirname, 'handlers'));
-    for (const listener of listeners) {
-      this.bot.on(listener, require(join(__dirname, 'handlers', listener)).handle.bind(this));
-    }
+    this.loadListeners();
     global.memeBase || this.ready();
     this.autopost = new (require('./utils/Autopost.js'))(this);
     if (cluster.worker.id === 1) {
@@ -113,35 +109,51 @@ class Memer extends Base {
     this.mockIMG = await this.http.get('https://pbs.twimg.com/media/DAU-ZPHUIAATuNy.jpg').then(r => r.body);
   }
 
-  createIPC () {
-    this.ipc.register('reloadCommands', this.reloadCommands.bind(this));
-    this.ipc.register('reloadMost', () => {
-      for (const path in require.cache) {
-        if (path.includes('src/utils') || path.includes('src/commands') || path.includes('src/models') || path.includes('src/assets') || path.includes('src/handlers')) {
-          delete require.cache[path];
-        }
-      }
-      this.cmds = [];
-      this.loadCommands();
-      this.loadUtils();
-      this.log('Most things reloaded probably');
-    });
-    this.ipc.register('reloadConfig', () => {
-      for (const path in require.cache) {
-        if (path.includes('src/config')) {
-          delete require.cache[path];
-        }
-      }
-      this.config = require('./config.json');
-      this.log('Config reloaded probably');
-    });
+  loadListeners () {
+    this.listeners.ready = this.ready.bind(this);
+    this.bot.on('ready', this.listeners.ready);
+    const listeners = require(join(__dirname, 'handlers'));
+    for (const listener of listeners) {
+      this.listeners[listener] = require(join(__dirname, 'handlers', listener)).handle.bind(this);
+      this.bot.on(listener, this.listeners[listener]);
+    }
   }
 
-  async loadUtils () {
+  removeListeners () {
+    for (const listener in this.listeners) {
+      this.bot.removeListener(listener, this.listeners[listener]);
+    }
+  }
+
+  createIPC () {
+    this.ipc.register('reloadCommands', this.reloadCommands.bind(this));
+    this.ipc.register('reloadListeners', this.reloadListeners.bind(this));
+    this.ipc.register('reloadAll', this.reload.bind(this));
+    this.ipc.register('reloadModels', this.reloadModels.bind(this));
+    this.ipc.register('reloadUtils', this.reloadUtils.bind(this));
+    this.ipc.register('reloadConfig', this.reloadConfig.bind(this));
+  }
+
+  reloadUtils () {
+    const utilsPath = join(__dirname, 'utils');
+    for (const path in require.cache) {
+      if (path.startsWith(utilsPath)) {
+        delete require.cache[path];
+      }
+    }
     this.log = require('./utils/logger.js');
-    this.db = require('./utils/dbFunctions.js')(this);
-    this.redis = await require('./utils/redisClient.js')(this.config.redis);
-    Object.assign(this, require('./utils/misc.js'));
+    this.db = new (require('./utils/dbFunctions.js'))(this);
+    this.http = require('./utils/http');
+    this.bot.removeListener('messageCreate', this.MessageCollector._boundVerify);
+    MessageCollector = require('./utils/MessageCollector.js');
+    this.MessageCollector = new MessageCollector(this.bot);
+    this.autopost = new (require('./utils/Autopost.js'))(this);
+    const MiscFunctions = new (require('./utils/misc.js'))();
+    for (const key of Object.getOwnPropertyNames(Object.getPrototypeOf(MiscFunctions))) {
+      if (key !== 'constructor') {
+        this[key] = MiscFunctions[key];
+      }
+    }
   }
 
   loadCommands () {
@@ -153,6 +165,7 @@ class Memer extends Base {
       for (const command of category.commands) {
         command.category = category.name;
         command.description = category.description;
+        command.path = join(__dirname, 'commands', categoryPath, command.props.triggers[0]);
         this.cmds.push(command);
       }
     }
@@ -162,30 +175,65 @@ class Memer extends Base {
     return botPackage;
   }
 
+  reloadConfig () {
+    delete require.cache[require.resolve('./config')];
+    delete require.cache[require.resolve('./secrets')];
+    delete require.cache[require.resolve('../package')];
+    botPackage = require('../package');
+    this.config = require('./config');
+    this.secrets = require('./secrets');
+  }
+
+  reloadModels () {
+    const modelsPath = require.resolve(join(__dirname, 'models'));
+    for (const path in require.cache) {
+      if (path.startsWith(modelsPath)) {
+        delete require.cache[path];
+      }
+    }
+    Memer.log(`Reloaded models`);
+  }
+
+  reloadListeners () {
+    const listenersPath = join(__dirname, 'handlers');
+    for (const path in require.cache) {
+      if (path.startsWith(listenersPath)) {
+        delete require.cache[path];
+      }
+    }
+    this.removeListeners();
+    this.loadListeners();
+    this.log(`Reloaded event listeners`);
+  }
+
   reloadCommands (msg) {
     if (msg.category) {
-      const categoryPath = require.resolve(join(__dirname, 'commands', msg.category));
+      const categoryPath = join(__dirname, 'commands', `${msg.category}Commands`);
       const categoryDir = readdirSync(categoryPath);
       for (const file of categoryDir) {
-        delete require.cache[require.resolve(join(__dirname, 'commands', msg.category, file))];
+        delete require.cache[require.resolve(`${categoryPath}/${file}`)];
       }
       const category = require(categoryPath);
       let reloadedCmds = [];
       for (const command of category.commands) {
         command.category = category.name;
         command.description = category.description;
+        command.path = require.resolve(`${categoryPath}/${command.props.triggers[0]}`);
         reloadedCmds.push(command);
       }
-      this.cmds = this.cmds.filter(c => c.category !== category.name).concat(reloadedCmds);
+      this.cmds = this.cmds.filter(c => !c.path.includes(`${msg.category}Commands`)).concat(reloadedCmds);
+      this.log(`Reloaded command category ${msg.category}`);
     } else if (msg.command) {
       const cmd = this.cmds.find(c => c.props.triggers.includes(msg.command));
-      const cmdPath = require.resolve(join(__dirname, 'commands', cmd.category, cmd.props.triggers[0]));
+      const cmdPath = require.resolve(cmd.path);
       delete require.cache[cmdPath];
       const reloadedCmd = require(cmdPath);
       reloadedCmd.category = cmd.category;
       reloadedCmd.description = cmd.description;
-      this.cmds = this.cmds.splice(this.cmds.findIndex(c => c.props.triggers.includes(msg.command), 1));
+      reloadedCmd.path = cmd.path;
+      this.cmds.splice(this.cmds.findIndex(c => c.props.triggers.includes(msg.command), 1));
       this.cmds.push(reloadedCmd);
+      this.log(`Reloaded command ${reloadedCmd.props.triggers[0]}`);
     } else {
       const commandPath = join(__dirname, 'commands');
       for (const path in require.cache) {
@@ -195,7 +243,39 @@ class Memer extends Base {
       }
       this.cmds = [];
       this.loadCommands();
+      this.log(`Reloaded all ${this.cmds.length} commands`);
     }
+  }
+
+  reload () {
+    for (const path in require.cache) {
+      if (path.startsWith(__dirname)) {
+        delete require.cache[path];
+      }
+    }
+    for (const key of this.ipc.events) {
+      this.ipc.events.delete(key);
+    }
+    process.removeAllListeners('message');
+    this.removeListeners();
+    this.bot.removeListener('messageCreate', this.MessageCollector._boundVerify);
+    this.r.getPoolMaster().drain();
+    this.redis.disconnect();
+    this.ddog.close();
+    for (const node of this.lavalink.nodes) {
+      for (const player of node.players) {
+        node.players.get(player).destroy();
+      }
+      try {
+        node.connection.ws.close();
+      } catch (err) {}
+    }
+    const intervals = [this._cooldownsSweep, this._autopostInterval];
+    for (const interval of intervals) {
+      clearInterval(interval);
+    }
+    const Memer = require(module.filename);
+    new Memer({ bot: this.bot, clusterID: this.clusterID }).launch();
   }
 
   _sweepCooldowns () {

--- a/src/utils/ArgParser.js
+++ b/src/utils/ArgParser.js
@@ -135,7 +135,7 @@ class ArgParser {
 
   /**
    * Returns the next word(s) in the argument list
-   * @param {Boolean} consumeRest Whether to return the remaining arguments or a single argument
+   * @param {Boolean} [consumeRest=false] Whether to return the remaining arguments or a single argument, defaults to `false`
    * @return {Null|String} Null if the arg list is empty, otherwise the arguments
    */
   nextArgument (consumeRest = false) {

--- a/src/utils/MessageCollector.js
+++ b/src/utils/MessageCollector.js
@@ -1,8 +1,8 @@
 module.exports = class MessageCollector {
   constructor (bot) {
     this.collectors = {};
-
-    bot.on('messageCreate', this.verify.bind(this));
+    this._boundVerify = this.verify.bind(this);
+    bot.on('messageCreate', this._boundVerify);
   }
 
   async verify (msg) {


### PR DESCRIPTION
This PR greatly enhance our hot reload capabilities, so let's get started:

> `pls d reload category utility`: Reloads the command category `utility`, the valid category names are the ones in the folder name (`Commands` part is dropped)

> `pls d reload command help`: Reloads the `help` command

> `pls d reload commands | pls d reload command all`: Reload all commands, should be used to reload dev commands as well

> `pls d reload utils`: Reload all utils except RedisClient (`reload all` should be used for that)

> `pls d reload events`: Reload all event listeners (`src/handlers`)

> `pls d reload models`: Reload all models. Though, in most cases, memer will still use the old ones, like if you change the `GenericCommand` model, you'll also need to reload all commands to have them use the updated model

> `pls d reload all`: Reload everything, including `mainClass`. Acts like the cluster is rebooted, but the shards connections are preserved. It will ask if we want to preserve connections to redis and stuff, not-preserving them should **not** be chosen unless we need to reload them, like if we need to update the libs versions for example. 

> `pls d reload config`: Reload the config, secrets and package

* Works on windows too :^) (The issue was probably that windows sometimes uses `\` in paths and dank memer was expecting `/`)

# Other changes

* Updated `package.json`

- * Bumped version to `6.0.0`
- * Updated `lavalink` from `2.1.1` to `2.2.2`
- * Set back eris-sharder to `github:Discord-Sharders/eris-sharder#dev`, as `1.7.9` is outdated 
- * Moved `eslint` related packages to `devDependencies` so they can be omitted with the `--production` flag on production servers
- * Added `@types/node` in `devDependencies` to benefit from better intellisense for node.js stuff