### PR TITLE
IPC

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -12,6 +12,7 @@
         "path": "",
         "shardCount": 0,
         "clusters": 0,
+        "guildsPerShard": 1300,
         "webhooks": {
             "shard": {
                 "id": "",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-standard": "^4.0.0",
+    "eslint-plugin-import": "^2.14.0",
     "@types/node": "^10.11.7"
   }
 }

--- a/src/commands/currencyCommands/rich.js
+++ b/src/commands/currencyCommands/rich.js
@@ -10,11 +10,7 @@ module.exports = new GenericCommand(
       return 'bot is still loading, hold ur horses damn';
     }
     if (args && args[0] === '-all') {
-      const bigmeme = (id) => new Promise(resolve => {
-        setTimeout(() => resolve({ id }), 1000);
-        Memer.ipc.fetchUser(id)
-          .then(resolve); // this is intentional and also stupid but still intentional
-      });
+      const bigmeme = (id) => Memer.IPC.fetchUser(id).then(u => u || { id });
 
       let pls = await Memer.redis.zrevrange(`pocket-leaderboard`, 0, 9, 'WITHSCORES');
       pls = Memer.paginateArray(pls, 2).map(entry => {
@@ -46,7 +42,7 @@ module.exports = new GenericCommand(
       }
       pls = pls.filter(u => u.pocket > 0);
       pls = pls.sort((a, b) => b.pocket - a.pocket).slice(0, 5);
-      pls = await Promise.all(pls.map(g => Memer.ipc.fetchUser(g.id).then(res => { return { ...res, pocket: g.pocket }; })));
+      pls = await Promise.all(pls.map(g => Memer.IPC.fetchUser(g.id).then(res => { return { ...res, pocket: g.pocket }; })));
       return {
         title: `richest users in this server`,
         description: pls.map((u, i) => `${emojis[i] || '👏'} ${u.pocket.toLocaleString()} - ${u.username}#${u.discriminator}`).join('\n'),

--- a/src/commands/currencyCommands/rich.js
+++ b/src/commands/currencyCommands/rich.js
@@ -10,7 +10,7 @@ module.exports = new GenericCommand(
       return 'bot is still loading, hold ur horses damn';
     }
     if (args && args[0] === '-all') {
-      const bigmeme = (id) => Memer.IPC.fetchUser(id).then(u => u || { id });
+      const bigmeme = (id) => Memer.IPC.fetchUser(id, 2000).then(u => u || { id });
 
       let pls = await Memer.redis.zrevrange(`pocket-leaderboard`, 0, 9, 'WITHSCORES');
       pls = Memer.paginateArray(pls, 2).map(entry => {
@@ -42,7 +42,7 @@ module.exports = new GenericCommand(
       }
       pls = pls.filter(u => u.pocket > 0);
       pls = pls.sort((a, b) => b.pocket - a.pocket).slice(0, 5);
-      pls = await Promise.all(pls.map(g => Memer.IPC.fetchUser(g.id).then(res => { return { ...res, pocket: g.pocket }; })));
+      pls = await Promise.all(pls.map(g => Memer.IPC.fetchUser(g.id, 2000).then(res => { return { ...res, pocket: g.pocket }; })));
       return {
         title: `richest users in this server`,
         description: pls.map((u, i) => `${emojis[i] || '👏'} ${u.pocket.toLocaleString()} - ${u.username}#${u.discriminator}`).join('\n'),

--- a/src/commands/utilityCommands/dev/commands/broadcasteval.js
+++ b/src/commands/utilityCommands/dev/commands/broadcasteval.js
@@ -1,0 +1,20 @@
+/** @typedef {import('../../../../models/GenericCommand').FunctionParams} FunctionParams */
+
+module.exports = {
+  help: 'broadcasteval <script>',
+  /** @param {FunctionParams} */
+  fn: async ({ Memer, msg, args }) => {
+    if (!Memer.config.options.owners.includes(msg.author.id)) {
+      return 'Woah now, only my "Owners" can do this';
+    }
+    const m = await msg.channel.createMessage('Ok this may take a few seconds so sit tight');
+    const responses = await Memer.IPC.broadcastEval(args.join(' '));
+    let res = '';
+    for (let i = 1; i < Memer.config.sharder.clusters; i++) {
+      const clusterResponse = responses.find(r => r.clusterID === i);
+      res += `[Cluster ${i}]: ${clusterResponse ? clusterResponse.data : 'timed out'}\n`;
+    }
+    m.edit(res);
+    return `Broadcast eval done`;
+  }
+};

--- a/src/commands/utilityCommands/dev/commands/broadcasteval.js
+++ b/src/commands/utilityCommands/dev/commands/broadcasteval.js
@@ -10,7 +10,7 @@ module.exports = {
     const m = await msg.channel.createMessage('Ok this may take a few seconds so sit tight');
     const responses = await Memer.IPC.broadcastEval(args.join(' '));
     let res = '';
-    for (let i = 1; i < Memer.config.sharder.clusters; i++) {
+    for (let i = 1; i <= Memer.config.sharder.clusters; i++) {
       const clusterResponse = responses.find(r => r.clusterID === i);
       res += `[Cluster ${i}]: ${clusterResponse ? clusterResponse.data : 'timed out'}\n`;
     }

--- a/src/commands/utilityCommands/dev/commands/reload.js
+++ b/src/commands/utilityCommands/dev/commands/reload.js
@@ -24,7 +24,7 @@ module.exports = {
           if (!category) {
             return `You gotta specify a category to reload stupid`;
           }
-          Memer.ipc.broadcast('reloadCommands', { category });
+          Memer.IPC.broadcast('reloadCommands', { category });
           return `Reloaded command category ${category}`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
@@ -32,21 +32,21 @@ module.exports = {
       case 'command':
         try {
           const command = msg.args.nextArgument(false).toLowerCase();
-          Memer.ipc.broadcast('reloadCommands', command === 'all' ? {} : { command });
+          Memer.IPC.broadcast('reloadCommands', command === 'all' ? {} : { command });
           return `Reloaded ${command === 'all' ? 'all commands' : (command + ' command')}`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
         }
       case 'events':
         try {
-          Memer.ipc.broadcast('reloadListeners', {});
+          Memer.IPC.broadcast('reloadListeners', {});
           return `Reloaded all event listeners`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
         }
       case 'commands':
         try {
-          Memer.ipc.broadcast('reloadCommands', {});
+          Memer.IPC.broadcast('reloadCommands', {});
           return `Reloaded all commands`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
@@ -56,28 +56,28 @@ module.exports = {
           await msg.channel.createMessage(`Preserve connections to lavalink/redis/rethink...? \`y\`/\`n\``);
           let choice = await Memer.MessageCollector.awaitMessage(msg.channel.id, msg.author.id, 5e4);
           choice = (!choice || choice.content.toLowerCase() === 'y');
-          Memer.ipc.broadcast('reloadAll', { preserveConnections: choice });
+          Memer.IPC.broadcast('reloadAll', { preserveConnections: choice });
           return `Reloaded welp everything`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
         }
       case 'config':
         try {
-          Memer.ipc.broadcast('reloadConfig', {});
+          Memer.IPC.broadcast('reloadConfig', {});
           return `Reloaded config`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
         }
       case 'utils':
         try {
-          Memer.ipc.broadcast('reloadUtils', {});
+          Memer.IPC.broadcast('reloadUtils', {});
           return `Reloaded utils`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;
         }
       case 'models':
         try {
-          Memer.ipc.broadcast('reloadModels', {});
+          Memer.IPC.broadcast('reloadModels', {});
           return `Reloaded models`;
         } catch (err) {
           return `We had a hecking error: \n\`\`\`${err.stack || err.message || err}\`\`\``;

--- a/src/commands/utilityCommands/dev/commands/rollingrestart.js
+++ b/src/commands/utilityCommands/dev/commands/rollingrestart.js
@@ -1,0 +1,20 @@
+/** @typedef {import('../../../../models/GenericCommand').FunctionParams} FunctionParams */
+
+module.exports = {
+  help: 'rollingrestart',
+  /** @param {FunctionParams} */
+  fn: async ({ Memer, msg }) => {
+    if (!Memer.config.options.owners.includes(msg.author.id)) {
+      return 'Woah now, only my "Owners" can do this';
+    }
+    const m = await msg.channel.createMessage(`Are you sure about this? \`y\`/\`n\``);
+
+    const choice = await Memer.MessageCollector.awaitMessage(msg.channel.id, msg.author.id, 5e4);
+    if (!choice || choice.content.toLowerCase() !== 'y') {
+      m.edit('whew, dodged a bullet');
+      return;
+    }
+    Memer.IPC.rollingRestart();
+    return `Rolling restart started`;
+  }
+};

--- a/src/commands/utilityCommands/dev/commands/spam.js
+++ b/src/commands/utilityCommands/dev/commands/spam.js
@@ -1,11 +1,8 @@
 module.exports = {
   help: 'who spammin',
   fn: async ({ Memer }) => {
-    const bigmeme = (id) => new Promise(resolve => {
-      setTimeout(() => resolve({ id }), 1000);
-      Memer.ipc.fetchUser(id)
-        .then(resolve); // this is intentional and also stupid but still intentional
-    });
+    const bigmeme = (id) => Memer.IPC.fetchUser(id).then(u => u || { id });
+
     let pls = await Memer.db.topSpam();
     pls = await Promise.all(pls.map(async g => Object.assign(await bigmeme(g.id), { pls: g.spam })));
     return {

--- a/src/commands/utilityCommands/dev/commands/spam.js
+++ b/src/commands/utilityCommands/dev/commands/spam.js
@@ -1,7 +1,7 @@
 module.exports = {
   help: 'who spammin',
   fn: async ({ Memer }) => {
-    const bigmeme = (id) => Memer.IPC.fetchUser(id).then(u => u || { id });
+    const bigmeme = (id) => Memer.IPC.fetchUser(id, 2000).then(u => u || { id });
 
     let pls = await Memer.db.topSpam();
     pls = await Promise.all(pls.map(async g => Object.assign(await bigmeme(g.id), { pls: g.spam })));

--- a/src/commands/utilityCommands/dev/commands/update.js
+++ b/src/commands/utilityCommands/dev/commands/update.js
@@ -15,7 +15,7 @@ module.exports = {
     for (const subscriber of subscribers) {
       promises.push(
         Memer.bot.createMessage(subscriber.channelID, args.join(' '))
-          .catch(() => Memer.ipc.fetchGuild(subscriber.id)
+          .catch(() => Memer.IPC.fetchGuild(subscriber.id)
             .then(guild => Memer.bot.getDMChannel(guild.ownerID)
               .then(dm => dm.createMessage(`The Update Channel is deleted or I dont have permissions to talk in the update channel you idiot!!! Anyway here is the update info\n\n ${args.join(' ')}`)
                 .catch(() => Memer.db.deleteDevSubscriber(subscriber.id))

--- a/src/commands/utilityCommands/dev/commands/user.js
+++ b/src/commands/utilityCommands/dev/commands/user.js
@@ -8,7 +8,7 @@ module.exports = {
 
     let db = userEntry.props;
     donor = donor ? donor.donorAmount : false;
-    let user = await Memer.ipc.fetchUser(id);
+    let user = await Memer.IPC.fetchUser(id);
     let blacklisted = await Memer.db.checkBlocked(id);
     return {
       title: `${user.username}#${user.discriminator} ${id}`,

--- a/src/commands/utilityCommands/leaderboard.js
+++ b/src/commands/utilityCommands/leaderboard.js
@@ -7,17 +7,13 @@ module.exports = new GenericCommand(
     if (stats.clusters[stats.clusters.length - 1].uptime === 0) {
       return 'bot is still loading, hold ur horses damn';
     }
-    const bigmeme = (id) => new Promise(resolve => {
-      setTimeout(() => resolve({ id }), 1000);
-      Memer.ipc.fetchGuild(id)
-        .then(resolve); // this is intentional and also stupid but still intentional
-    });
+    const bigmeme = (id) => Memer.IPC.fetchGuild(id).then(g => g || { id });
 
     let pls = await Memer.db.topPls();
     let you = await Memer.db.getPls(msg.channel.guild.id);
     pls = await Promise.all(pls.map(async g => Object.assign(await bigmeme(g.id), { pls: g.pls })));
     return {
-      title: 'Top 15 servers (Commands Ran)',
+      title: 'Top 10 servers (Commands Ran)',
       description: pls.map((g, i) => `${emojis[i] || '👏'} ${g.pls.toLocaleString()} - ${g.name || 'LOL WHO DIS'}`).join('\n'),
       footer: { text: `Your server has ran ${you.pls} commands` }
     };

--- a/src/commands/utilityCommands/leaderboard.js
+++ b/src/commands/utilityCommands/leaderboard.js
@@ -7,7 +7,7 @@ module.exports = new GenericCommand(
     if (stats.clusters[stats.clusters.length - 1].uptime === 0) {
       return 'bot is still loading, hold ur horses damn';
     }
-    const bigmeme = (id) => Memer.IPC.fetchGuild(id).then(g => g || { id });
+    const bigmeme = (id) => Memer.IPC.fetchGuild(id, 2000).then(g => g || { id });
 
     let pls = await Memer.db.topPls();
     let you = await Memer.db.getPls(msg.channel.guild.id);

--- a/src/commands/utilityCommands/premiumserver.js
+++ b/src/commands/utilityCommands/premiumserver.js
@@ -48,7 +48,7 @@ module.exports = new GenericCommand(
           let index = 0;
           let tosend = [];
           for (let id of guilds) {
-            const guild = await Memer.ipc.fetchGuild(id);
+            const guild = await Memer.IPC.fetchGuild(id);
             tosend.push(guilds.length ? `\`${index += 1}.\` **${guild.name}** (${id})\n` : 'You have redeemed no premium servers');
           }
           return tosend.join('');

--- a/src/commands/utilityCommands/topusers.js
+++ b/src/commands/utilityCommands/topusers.js
@@ -8,11 +8,7 @@ module.exports = new GenericCommand(
       return 'bot is still loading, hold ur horses damn';
     }
     if (args && args[0] === '-all') {
-      const bigmeme = (id) => new Promise(resolve => {
-        setTimeout(() => resolve({ id }), 1000);
-        Memer.IPC.fetchUser(id)
-          .then(resolve); // this is intentional and also stupid but still intentional
-      });
+      const bigmeme = (id) => Memer.IPC.fetchUser(id, 2000).then(u => u || { id });
       let pls = await Memer.redis.zrevrange(`pls-leaderboard`, 0, 9, 'WITHSCORES');
       pls = Memer.paginateArray(pls, 2).map(entry => {
         return {
@@ -43,7 +39,7 @@ module.exports = new GenericCommand(
       }
       pls = pls.filter(u => u.pls > 0);
       pls = pls.sort((a, b) => b.pls - a.pls).slice(0, 5);
-      pls = await Promise.all(pls.map(g => Memer.IPC.fetchUser(g.id).then(res => { return { ...res, pls: g.pls }; })));
+      pls = await Promise.all(pls.map(g => Memer.IPC.fetchUser(g.id, 2000).then(res => { return { ...res, pls: g.pls }; })));
       return {
         title: `who uses the bot the most`,
         description: pls.map((u, i) => `${emojis[i] || '👏'} ${u.pls} - ${u.username}#${u.discriminator}`).join('\n'),

--- a/src/commands/utilityCommands/topusers.js
+++ b/src/commands/utilityCommands/topusers.js
@@ -10,7 +10,7 @@ module.exports = new GenericCommand(
     if (args && args[0] === '-all') {
       const bigmeme = (id) => new Promise(resolve => {
         setTimeout(() => resolve({ id }), 1000);
-        Memer.ipc.fetchUser(id)
+        Memer.IPC.fetchUser(id)
           .then(resolve); // this is intentional and also stupid but still intentional
       });
       let pls = await Memer.redis.zrevrange(`pls-leaderboard`, 0, 9, 'WITHSCORES');
@@ -43,7 +43,7 @@ module.exports = new GenericCommand(
       }
       pls = pls.filter(u => u.pls > 0);
       pls = pls.sort((a, b) => b.pls - a.pls).slice(0, 5);
-      pls = await Promise.all(pls.map(g => Memer.ipc.fetchUser(g.id).then(res => { return { ...res, pls: g.pls }; })));
+      pls = await Promise.all(pls.map(g => Memer.IPC.fetchUser(g.id).then(res => { return { ...res, pls: g.pls }; })));
       return {
         title: `who uses the bot the most`,
         description: pls.map((u, i) => `${emojis[i] || '👏'} ${u.pls} - ${u.username}#${u.discriminator}`).join('\n'),

--- a/src/mainClass.js
+++ b/src/mainClass.js
@@ -129,12 +129,12 @@ class Memer extends Base {
   }
 
   createIPC () {
-    this.ipc.register('reloadCommands', this.reloadCommands.bind(this));
-    this.ipc.register('reloadListeners', this.reloadListeners.bind(this));
-    this.ipc.register('reloadAll', this.reload.bind(this));
-    this.ipc.register('reloadModels', this.reloadModels.bind(this));
-    this.ipc.register('reloadUtils', this.reloadUtils.bind(this));
-    this.ipc.register('reloadConfig', this.reloadConfig.bind(this));
+    this.IPC.register('reloadCommands', this.reloadCommands.bind(this));
+    this.IPC.register('reloadListeners', this.reloadListeners.bind(this));
+    this.IPC.register('reloadAll', this.reload.bind(this));
+    this.IPC.register('reloadModels', this.reloadModels.bind(this));
+    this.IPC.register('reloadUtils', this.reloadUtils.bind(this));
+    this.IPC.register('reloadConfig', this.reloadConfig.bind(this));
   }
 
   reloadUtils () {

--- a/src/mainClass.js
+++ b/src/mainClass.js
@@ -57,6 +57,7 @@ class Memer extends Base {
     this.lavalink = reload.lavalink;
     this.listeners = {};
     this.cooldowns = new Map();
+    this.IPC = new (require('./utils/IPCHandler.js'))(this);
     this._cooldownsSweep = setInterval(this._sweepCooldowns.bind(this), 1000 * 60 * 30);
     // work-around to benefit from nice documentation and still have misc functions assigned on the Memer instance
     const MiscFunctions = new (require('./utils/misc.js'))();
@@ -150,6 +151,7 @@ class Memer extends Base {
     MessageCollector = require('./utils/MessageCollector.js');
     this.MessageCollector = new MessageCollector(this.bot);
     this.autopost = new (require('./utils/Autopost.js'))(this);
+    this.IPC = new (require('./utils/IPCHandler.js'))(this);
     const MiscFunctions = new (require('./utils/misc.js'))();
     for (const key of Object.getOwnPropertyNames(Object.getPrototypeOf(MiscFunctions))) {
       if (key !== 'constructor') {

--- a/src/mainClass.js
+++ b/src/mainClass.js
@@ -84,6 +84,7 @@ class Memer extends Base {
   }
 
   async ready () {
+    this.IPC.sendTo(1, 'memerIPC', { type: 'restartDone', clusterID: this.clusterID });
     const { bot } = this;
     this.lavalink = this.lavalink || new Cluster({
       nodes: this.config.lavalink.nodes.map(node => ({

--- a/src/memer.js
+++ b/src/memer.js
@@ -28,7 +28,8 @@ const master = new Sharder(secrets.bot.token, config.sharder.path, {
   clientOptions: config.eris.clientOptions,
   shards: config.sharder.shardCount || 1,
   statsInterval: config.statsInterval || 1e4,
-  clusters: config.sharder.clusters || undefined
+  clusters: config.sharder.clusters || undefined,
+  guildsPerShard: config.sharder.guildsPerShard
 });
 
 // Record bot stats every x seconds/minutes to the database

--- a/src/models/GenericCommand.js
+++ b/src/models/GenericCommand.js
@@ -25,6 +25,7 @@
  * @prop {import('eris').Client} bot The eris client instance
  * @prop {import('../utils/Autopost')} autopost The auto-poster
  * @prop {Array<Object>} cmds An array of all the commands
+ * @prop {import('../utils/IPCHandler')} IPC Custom IPC interface, allows a more reliable communication across clusters
  */
 
 /** @typedef {MemerBase & MiscFunctions} Memer */

--- a/src/utils/Autopost.js
+++ b/src/utils/Autopost.js
@@ -116,7 +116,7 @@ module.exports = class Autopost {
           })
           .then(async (message) => {
             // Check if the channel in which the message was sent is NSFW, and if not, removes the channel from the db and try to delete the message
-            let grabbedChannel = await this._fetchChannel(message.channel_id);
+            let grabbedChannel = await this.client.IPC.fetchChannel(message.channel_id, 2000);
             if (!grabbedChannel) {
               grabbedChannel = await this.client.bot.getRESTChannel(message.channel_id)
                 .catch(err => err.code);
@@ -131,14 +131,6 @@ module.exports = class Autopost {
           });
       }
     }
-  }
-
-  async _fetchChannel (id) { // Because eris-sharder sucks hard
-    return new Promise(resolve => {
-      setTimeout(() => resolve({ id }), 2000);
-      this.client.IPC.fetchChannel(id)
-        .then(resolve);
-    });
   }
 
   async post () {

--- a/src/utils/Autopost.js
+++ b/src/utils/Autopost.js
@@ -136,7 +136,7 @@ module.exports = class Autopost {
   async _fetchChannel (id) { // Because eris-sharder sucks hard
     return new Promise(resolve => {
       setTimeout(() => resolve({ id }), 2000);
-      this.client.ipc.fetchChannel(id)
+      this.client.IPC.fetchChannel(id)
         .then(resolve);
     });
   }

--- a/src/utils/IPCHandler.js
+++ b/src/utils/IPCHandler.js
@@ -1,0 +1,269 @@
+/** @typedef {import("../models/GenericCommand").Memer} Memer 
+*/
+
+/** @typedef {Object} ClusterStats
+ * @prop {Number} cluster The ID of the cluster
+ * @prop {Number} shards The amount of shards on this cluster
+ * @prop {Number} guilds The total amount of guilds across all clusters
+ * @prop {Number} ram The RSS RAM usage of this cluster (in MB)
+ * @prop {Number} voice The amount of voice connections on this cluster
+ * @prop {Number} uptime The uptime of this cluster in milliseconds
+ * @prop {Number} exclusiveGuilds The amount of guilds on this cluster
+ * @prop {Number} largeGuilds The amount of large guilds on this cluster (250+ members)
+ */
+
+class IPCHandler {
+    /**
+     * @param {Memer} client The Memer instance
+     */
+    constructor(client) {
+        /** @type {Map} A map of the current ongoing requests */
+        this.requests = new Map();
+        /** @type {Memer} The Memer instance */
+        this.client = client;
+        this._handleIncomingMessage = this._handleIncomingMessage.bind(this);
+        this.client.ipc.register('memerIPC', this._handleIncomingMessage);
+        this._idsGenerated = 0;
+    }
+
+    /**
+     * Returns a new unique ID
+     *
+     * @readonly
+     * @memberof IPCHandler
+     * @type {String}
+     */
+    get uid () {
+        return `${Date.now()}-${process.pid}-${this._idsGenerated++}`;
+    }
+
+    /**
+     * Fetch the stats of the shards of each cluster
+     * @returns {Promise<Array>} An array of clusters with their shards stats
+     */
+    fetchShardsStats() {
+        const ID = Date.now();
+        return new Promise(resolve => {
+            this.requests.set(ID, {
+                responses: [],
+                resolve: resolve
+            });
+            this.client.ipc.broadcast("fetchShardsStats", {
+                id: ID,
+                type: "fetchShardsStats",
+                clusterID: this.client.clusterID
+            });
+        });
+    }
+
+    /**
+     *
+     * @param {string} type - The type of the file that should be reloaded, either "command", "event" or "module"
+     * @param {string} path - The absolute path of the file that should be reloaded
+     * @param {string} [name] - If a module, the name of the module
+     * @param {object} [options] - If a module, the options that Reloader.reloadModule() expect
+     * @returns {Promise<array>} An array containing the responses of each clusters, if the reload failed in at least one cluster, the promise is rejected
+     */
+    broadcastReload(type, path, name, options) {
+        const ID = `${this.client.utils.getRandomNumber(1000, 10000) + Date.now()}`;
+        return new Promise((resolve, reject) => {
+            this.requests.set(ID, {
+                responses: [],
+                resolve: resolve,
+                reject: reject
+            });
+            this.client.ipc.broadcast("reload", {
+                id: ID,
+                type: "reload",
+                clusterID: this.client.clusterID,
+                data: {
+                    type: type,
+                    path: path,
+                    name: name,
+                    options: options
+                }
+            });
+        });
+    }
+
+    fetchGuild(id) {
+        if (this.client.bot.guilds.has(id)) {
+            return this.client.bot.guilds.get(id);
+        }
+        const ID = `${this.client.getRandomNumber(1000, 10000) + Date.now()}`;
+        return new Promise((resolve, reject) => {
+            this.requests.set(ID, {
+                responses: [],
+                resolve: resolve,
+                reject: reject
+            });
+            this.client.ipc.broadcast("fetchGuild", {
+                id: ID,
+                type: "fetchGuild",
+                clusterID: this.client.clusterID,
+                data: id
+            });
+        });
+    }
+
+    /**
+     * Called every time the message event is fired on the process
+     * @param {*} message - The message
+     * @private
+     * @returns {void}
+     */
+    _handleIncomingMessage(message) {
+        switch (message.type) {
+        case "shardsStats":
+            let request = this.requests.get(message.id);
+            request.responses.push({clusterID: message.clusterID, data: message.data});
+
+            if (this._allClustersAnswered(message.id)) {
+                //Resolve the request and reorder the responses in case it wasn't already
+                request.resolve(request.responses.sort((a, b) => a.clusterID - b.clusterID));
+                this.requests.delete(message.id);
+            }
+            break;
+
+        case "statsUpdate":
+            this.client.stats = message.data;
+            if (!this.clusterCount) {
+                this.clusterCount = message.data.clusters.length;
+            }
+            break;
+
+        case "fetchShardsStats":
+            this.client.ipc.sendTo(message.clusterID, "shardsStats", {
+                type: "shardsStats",
+                id: message.id,
+                clusterID: this.client.clusterID,
+                data: this.client.bot.shards.map(shard => {
+                    return {
+                        id: shard.id,
+                        status: shard.status,
+                        latency: shard.latency,
+                        guilds: this.client.bot.guilds.filter(g => g.shard.id === shard.id).length,
+                        musicConnections: this.client.handlers.MusicManager
+                            ? this.client.handlers.MusicManager.connections.size
+                            : 0
+                    };
+                })
+            });
+            break;
+
+        case "reload":
+            let success = true;
+            try {
+                if (message.data.type === "event") {
+                    this.client.handlers.Reloader.reloadEventListener(message.data.path);
+                } else if (message.data.type === "command") {
+                    this.client.handlers.Reloader.reloadCommand(message.data.path);
+                } else if (message.data.type === "module") {
+                    this.client.handlers.Reloader.reloadModule(message.data.path, message.data.name, message.data.options);
+                } else if (message.data.type === "utils") {
+                    this.client.handlers.Reloader.reloadUtils();
+                } else if (message.data.type === "commands") {
+                    this.client.handlers.Reloader.reloadCommands();
+                } else if (message.data.type === "structures") {
+                    this.client.handlers.Reloader.reloadStructures();
+                } else if (message.data.type === "handlers") {
+                    this.client.handlers.Reloader.reloadHandlers();
+                } else if (message.data.type === "events") {
+                    this.client.handlers.Reloader.reloadEventListener('all');
+                }
+            } catch (err) {
+                success = false;
+                this.client.bot.emit("error", err);
+            }
+
+            this.client.ipc.sendTo(message.clusterID, "reloadDone", {
+                type: "reloadDone",
+                id: message.id,
+                clusterID: this.client.clusterID,
+                data: success
+            });
+            break;
+
+        case "reloadDone":
+            let reloadRequest = this.requests.get(message.id);
+            if (!reloadRequest) {
+                return;
+            }
+            reloadRequest.responses.push({clusterID: message.clusterID, data: message.data});
+
+            if (this._allClustersAnswered(message.id)) {
+                //Resolve the request and reorder the responses in case it wasn't already
+                if (reloadRequest.responses.filter(r => !r.data)[0]) {
+                    reloadRequest.reject(reloadRequest.responses.sort((a, b) => a.clusterID - b.clusterID));
+                } else {
+                    reloadRequest.resolve(reloadRequest.responses.sort((a, b) => a.clusterID - b.clusterID));
+                }
+                this.requests.delete(message.id);
+            }
+            break;
+
+        case "fetchGuild":
+            let guild = this.client.bot.guilds.get(message.data);
+            if (guild) {
+                guild = {
+                    ...guild
+                }; //Shallow clone
+                guild.members = Array.from(guild.members.values());
+                guild.roles = Array.from(guild.roles.values());
+                guild.channels = Array.from(guild.channels.values());
+            }
+            this.client.ipc.sendTo(message.clusterID, "requestedGuild", {
+                type: "requestedGuild",
+                id: message.id,
+                clusterID: this.client.clusterID,
+                data: guild
+            });
+            break;
+
+        case "requestedGuild":
+            if (!this.requests.has(message.id)) {
+                return;
+            }
+            if (this._allClustersAnswered(message.id)) {
+                this.requests.get(message.id).resolve(message.data);
+                // @ts-ignore
+                return this.requests.delete(message.id);
+            }
+            if (message.data) {
+                this.requests.get(message.id).resolve(message.data);
+                // @ts-ignore
+                return this.requests.delete(message.id);
+            }
+            break;
+        }
+        if (process.argv.includes("--dev")) {
+            process.send({
+                name: "log",
+                msg: `Received the message ${message.type} from cluster ${message.clusterID}: ${JSON.stringify(message, null, 2)}`
+            });
+        }
+    }
+
+    /**
+     * Check if all the active clusters responded to a request
+     * @param {string} id - The ID of the request to check if all the clusters answered to
+     * @returns {boolean} Whether all the active clusters responded to the request
+     * @private
+     */
+    _allClustersAnswered(id) {
+        return this.requests.get(id).responses.length >= (
+            this.clusterCount
+                ? this.clusterCount - this.client.stats.clusters.filter(c => c.guilds < 1).length
+                : 1)
+            ? true
+            : false;
+    }
+
+    _reload() {
+        process.removeListener('message', this._handleIncomingMessage);
+        delete require.cache[module.filename];
+        return new(require(module.filename))(this.client, {requests: this.requests});
+    }
+}
+
+module.exports = IPCHandler;

--- a/src/utils/IPCHandler.js
+++ b/src/utils/IPCHandler.js
@@ -1,5 +1,22 @@
-/** @typedef {import("../models/GenericCommand").Memer} Memer 
+/** @typedef {import('../models/GenericCommand').Memer} Memer
+ * @typedef {import('eris').Guild} Guild
+ * @typedef {import('eris').User} User
+ * @typedef {import('eris').TextChannel} TextChannel
+ * @typedef {import('eris').VoiceChannel} VoiceChannel
+ * @typedef {import('eris').CategoryChannel} CategoryChannel
+ * @typedef {import('eris').AnyGuildChannel} AnyGuildChannel
+ * @typedef {import('eris').Member} Member
+ * @typedef {import('eris').Role} Role
+ * @typedef {import('eris').JSON}
 */
+
+/** @typedef {Object} ConvertedProperties
+ * @prop {Array<Role>} roles An array of roles on this guild
+ * @prop {Array<Member>} members An array of members on this guild
+ * @prop {Array<AnyGuildChannel>} channels An array of channels on this guild
+ */
+
+/** @typedef {Guild & ConvertedProperties} StringifiedGuild */
 
 /** @typedef {Object} ClusterStats
  * @prop {Number} cluster The ID of the cluster
@@ -13,257 +30,305 @@
  */
 
 class IPCHandler {
-    /**
+  /**
      * @param {Memer} client The Memer instance
      */
-    constructor(client) {
-        /** @type {Map} A map of the current ongoing requests */
-        this.requests = new Map();
-        /** @type {Memer} The Memer instance */
-        this.client = client;
-        this._handleIncomingMessage = this._handleIncomingMessage.bind(this);
-        this.client.ipc.register('memerIPC', this._handleIncomingMessage);
-        this._idsGenerated = 0;
-    }
+  constructor (client) {
+    /** @type {Map} A map of the current ongoing requests */
+    this.requests = new Map();
+    /** @type {Memer} The Memer instance */
+    this.client = client;
+    this._handleIncomingMessage = this._handleIncomingMessage.bind(this);
+    this.client.ipc.register('memerIPC', this._handleIncomingMessage);
+    this._idsGenerated = 0;
+  }
 
-    /**
+  /**
      * Returns a new unique ID
      *
      * @readonly
      * @memberof IPCHandler
      * @type {String}
      */
-    get uid () {
-        return `${Date.now()}-${process.pid}-${this._idsGenerated++}`;
-    }
+  get uid () {
+    return `${Date.now()}-${process.pid}-${this._idsGenerated++}`;
+  }
 
-    /**
-     * Fetch the stats of the shards of each cluster
-     * @returns {Promise<Array>} An array of clusters with their shards stats
-     */
-    fetchShardsStats() {
-        const ID = Date.now();
-        return new Promise(resolve => {
-            this.requests.set(ID, {
-                responses: [],
-                resolve: resolve
-            });
-            this.client.ipc.broadcast("fetchShardsStats", {
-                id: ID,
-                type: "fetchShardsStats",
-                clusterID: this.client.clusterID
-            });
-        });
-    }
+  /**
+    *
+    *
+    * @param {String} type The request type
+    * @param {*} data Additional data about the request
+    * @returns {Promise<*>}
+    * @memberof IPCHandler
+    * @private
+    */
+  _createRequest (type, data) {
+    return new Promise((resolve, reject) => {
+      const id = this.uid;
+      this.requests.set(id, {
+        responses: [],
+        resolve,
+        reject
+      });
+      this.client.ipc.broadcast('memerIPC', {
+        type,
+        id,
+        clusterID: this.client.clusterID,
+        data,
+        timeout: setTimeout(() => {
+          const request = this.requests.get(id);
+          if (request) {
+            request.resolve();
+            this.requests.delete(id);
+          }
+        }, 1000 * 15)
+      });
+    });
+  }
 
-    /**
-     *
-     * @param {string} type - The type of the file that should be reloaded, either "command", "event" or "module"
-     * @param {string} path - The absolute path of the file that should be reloaded
-     * @param {string} [name] - If a module, the name of the module
-     * @param {object} [options] - If a module, the options that Reloader.reloadModule() expect
-     * @returns {Promise<array>} An array containing the responses of each clusters, if the reload failed in at least one cluster, the promise is rejected
-     */
-    broadcastReload(type, path, name, options) {
-        const ID = `${this.client.utils.getRandomNumber(1000, 10000) + Date.now()}`;
-        return new Promise((resolve, reject) => {
-            this.requests.set(ID, {
-                responses: [],
-                resolve: resolve,
-                reject: reject
-            });
-            this.client.ipc.broadcast("reload", {
-                id: ID,
-                type: "reload",
-                clusterID: this.client.clusterID,
-                data: {
-                    type: type,
-                    path: path,
-                    name: name,
-                    options: options
-                }
-            });
-        });
-    }
+  _replyTo (message, type, data) {
+    this.client.ipc.sendTo(message.clusterID, 'memerIPC', {
+      type,
+      id: message.id,
+      clusterID: this.client.clusterID,
+      data: data
+    });
+  }
 
-    fetchGuild(id) {
-        if (this.client.bot.guilds.has(id)) {
-            return this.client.bot.guilds.get(id);
-        }
-        const ID = `${this.client.getRandomNumber(1000, 10000) + Date.now()}`;
-        return new Promise((resolve, reject) => {
-            this.requests.set(ID, {
-                responses: [],
-                resolve: resolve,
-                reject: reject
-            });
-            this.client.ipc.broadcast("fetchGuild", {
-                id: ID,
-                type: "fetchGuild",
-                clusterID: this.client.clusterID,
-                data: id
-            });
-        });
+  /**
+    *
+    *
+    * @param {String} id The ID of the guild to fetch
+    * @returns {Promise<StringifiedGuild>}
+    * @memberof IPCHandler
+    */
+  async fetchGuild (id) {
+    if (this.client.bot.guilds.has(id)) {
+      let guild = this.client.bot.guilds.get(id);
+      const members = Array.from(guild.members.values());
+      const roles = Array.from(guild.roles.values());
+      const channels = Array.from(guild.members.values());
+      guild = {
+        ...guild,
+        members,
+        roles,
+        channels
+      };
+      return this.toJSON(guild);
     }
+    return this._createRequest('fetchGuild', id);
+  }
 
-    /**
+  /**
+    *
+    *
+    * @param {String} id The ID of the user to fetch
+    * @returns {Promise<User>}
+    * @memberof IPCHandler
+    */
+  async fetchUser (id) {
+    if (this.client.bot.users.has(id)) {
+      return this.client.bot.users.get(id).toJSON();
+    }
+    return this._createRequest('fetchUser', id);
+  }
+
+  /**
+    *
+    *
+    * @param {String} id The ID of the channel to fetch
+    * @returns {Promise<AnyGuildChannel>}
+    * @memberof IPCHandler
+    */
+  async fetchChannel (id) {
+    let channel;
+    let channelGuild = this.client.bot.guilds.get(this.client.bot.channelGuildMap[id]);
+    if (channelGuild) {
+      channel = channelGuild.channels.get(id);
+    }
+    if (channel) {
+      return this.toJSON(channel);
+    }
+    return this._createRequest('fetchChannel', id);
+  }
+
+  /**
+   * Broadcast the given event to all clusters, uses eris-sharder's IPC
+   *
+   * @param {String} event The name of the event to broadcast
+   * @param {Object?} [data={}] Additional data to broadcast, defaults to `{}`
+   * @returns {void}
+   * @memberof IPCHandler
+   */
+  broadcast (event, data = {}) {
+    this.client.ipc.broadcast(event, data);
+  }
+
+  /**
+   * Register a callback for the given IPC event
+   *
+   * @param {String} event The name of the event to listen to
+   * @param {Function} callback The callback function, a `message` argument may be passed to it, this argument being the additional data emitted along with the event
+   * @returns {void}
+   * @memberof IPCHandler
+   */
+  register (event, callback) {
+    this.client.ipc.register(event, callback);
+  }
+
+  /**
+   *
+   *
+   * @param {String} code
+   * @returns {Promise<Array>} An array containing responses of each cluster
+   * @memberof IPCHandler
+   */
+  async broadcastEval (code) {
+    return this._createRequest('eval', code);
+  }
+
+  /**
      * Called every time the message event is fired on the process
-     * @param {*} message - The message
+     * @param {Object} message - The message
      * @private
      * @returns {void}
      */
-    _handleIncomingMessage(message) {
-        switch (message.type) {
-        case "shardsStats":
-            let request = this.requests.get(message.id);
-            request.responses.push({clusterID: message.clusterID, data: message.data});
-
-            if (this._allClustersAnswered(message.id)) {
-                //Resolve the request and reorder the responses in case it wasn't already
-                request.resolve(request.responses.sort((a, b) => a.clusterID - b.clusterID));
-                this.requests.delete(message.id);
-            }
-            break;
-
-        case "statsUpdate":
-            this.client.stats = message.data;
-            if (!this.clusterCount) {
-                this.clusterCount = message.data.clusters.length;
-            }
-            break;
-
-        case "fetchShardsStats":
-            this.client.ipc.sendTo(message.clusterID, "shardsStats", {
-                type: "shardsStats",
-                id: message.id,
-                clusterID: this.client.clusterID,
-                data: this.client.bot.shards.map(shard => {
-                    return {
-                        id: shard.id,
-                        status: shard.status,
-                        latency: shard.latency,
-                        guilds: this.client.bot.guilds.filter(g => g.shard.id === shard.id).length,
-                        musicConnections: this.client.handlers.MusicManager
-                            ? this.client.handlers.MusicManager.connections.size
-                            : 0
-                    };
-                })
-            });
-            break;
-
-        case "reload":
-            let success = true;
-            try {
-                if (message.data.type === "event") {
-                    this.client.handlers.Reloader.reloadEventListener(message.data.path);
-                } else if (message.data.type === "command") {
-                    this.client.handlers.Reloader.reloadCommand(message.data.path);
-                } else if (message.data.type === "module") {
-                    this.client.handlers.Reloader.reloadModule(message.data.path, message.data.name, message.data.options);
-                } else if (message.data.type === "utils") {
-                    this.client.handlers.Reloader.reloadUtils();
-                } else if (message.data.type === "commands") {
-                    this.client.handlers.Reloader.reloadCommands();
-                } else if (message.data.type === "structures") {
-                    this.client.handlers.Reloader.reloadStructures();
-                } else if (message.data.type === "handlers") {
-                    this.client.handlers.Reloader.reloadHandlers();
-                } else if (message.data.type === "events") {
-                    this.client.handlers.Reloader.reloadEventListener('all');
-                }
-            } catch (err) {
-                success = false;
-                this.client.bot.emit("error", err);
-            }
-
-            this.client.ipc.sendTo(message.clusterID, "reloadDone", {
-                type: "reloadDone",
-                id: message.id,
-                clusterID: this.client.clusterID,
-                data: success
-            });
-            break;
-
-        case "reloadDone":
-            let reloadRequest = this.requests.get(message.id);
-            if (!reloadRequest) {
-                return;
-            }
-            reloadRequest.responses.push({clusterID: message.clusterID, data: message.data});
-
-            if (this._allClustersAnswered(message.id)) {
-                //Resolve the request and reorder the responses in case it wasn't already
-                if (reloadRequest.responses.filter(r => !r.data)[0]) {
-                    reloadRequest.reject(reloadRequest.responses.sort((a, b) => a.clusterID - b.clusterID));
-                } else {
-                    reloadRequest.resolve(reloadRequest.responses.sort((a, b) => a.clusterID - b.clusterID));
-                }
-                this.requests.delete(message.id);
-            }
-            break;
-
-        case "fetchGuild":
-            let guild = this.client.bot.guilds.get(message.data);
-            if (guild) {
-                guild = {
-                    ...guild
-                }; //Shallow clone
-                guild.members = Array.from(guild.members.values());
-                guild.roles = Array.from(guild.roles.values());
-                guild.channels = Array.from(guild.channels.values());
-            }
-            this.client.ipc.sendTo(message.clusterID, "requestedGuild", {
-                type: "requestedGuild",
-                id: message.id,
-                clusterID: this.client.clusterID,
-                data: guild
-            });
-            break;
-
-        case "requestedGuild":
-            if (!this.requests.has(message.id)) {
-                return;
-            }
-            if (this._allClustersAnswered(message.id)) {
-                this.requests.get(message.id).resolve(message.data);
-                // @ts-ignore
-                return this.requests.delete(message.id);
-            }
-            if (message.data) {
-                this.requests.get(message.id).resolve(message.data);
-                // @ts-ignore
-                return this.requests.delete(message.id);
-            }
-            break;
+  _handleIncomingMessage (message) {
+    const request = this.requests.get(message.id);
+    if (!request && message.type.startsWith('requested')) {
+      return;
+    }
+    request.responses.push(message);
+    switch (message.type) {
+      case 'fetchGuild':
+        let guild = this.client.bot.guilds.get(message.data);
+        if (guild) {
+          const members = Array.from(guild.members.values());
+          const roles = Array.from(guild.roles.values());
+          const channels = Array.from(guild.members.values());
+          guild = {
+            ...guild,
+            members,
+            roles,
+            channels
+          };
         }
-        if (process.argv.includes("--dev")) {
-            process.send({
-                name: "log",
-                msg: `Received the message ${message.type} from cluster ${message.clusterID}: ${JSON.stringify(message, null, 2)}`
-            });
+        this._replyTo(message, 'requestedGuild', guild ? guild.toJSON() : undefined);
+        break;
+
+      case 'requestedGuild':
+        if (this._allClustersAnswered(message.id)) {
+          request.resolve(message.data);
+          clearTimeout(request.timeout);
+          return this.requests.delete(message.id);
         }
-    }
+        if (message.data) {
+          this.requests.get(message.id).resolve(message.data);
+          clearTimeout(request.timeout);
+          return this.requests.delete(message.id);
+        }
+        break;
 
-    /**
-     * Check if all the active clusters responded to a request
-     * @param {string} id - The ID of the request to check if all the clusters answered to
-     * @returns {boolean} Whether all the active clusters responded to the request
-     * @private
-     */
-    _allClustersAnswered(id) {
-        return this.requests.get(id).responses.length >= (
-            this.clusterCount
-                ? this.clusterCount - this.client.stats.clusters.filter(c => c.guilds < 1).length
-                : 1)
-            ? true
-            : false;
-    }
+      case 'fetchUser':
+        let user = this.client.bot.users.get(message.data);
+        this._replyTo(message, 'requestedUser', user ? user.toJSON() : user);
+        break;
 
-    _reload() {
-        process.removeListener('message', this._handleIncomingMessage);
-        delete require.cache[module.filename];
-        return new(require(module.filename))(this.client, {requests: this.requests});
+      case 'requestedUser':
+        if (this._allClustersAnswered(message.id)) {
+          request.resolve(message.data);
+          clearTimeout(request.timeout);
+          return this.requests.delete(message.id);
+        }
+        if (message.data) {
+          this.requests.get(message.id).resolve(message.data);
+          clearTimeout(request.timeout);
+          return this.requests.delete(message.id);
+        }
+        break;
+
+      case 'fetchChannel':
+        let channel;
+        let channelGuild = this.client.bot.guilds.get(this.client.bot.channelGuildMap[message.data]);
+        if (channelGuild) {
+          channel = channelGuild.channels.get(message.data);
+        }
+        this._replyTo(message, 'requestedChannel', channel ? channel.toJSON() : channel);
+        break;
+
+      case 'requestedChannel':
+        if (this._allClustersAnswered(message.id)) {
+          request.resolve(message.data);
+          clearTimeout(request.timeout);
+          return this.requests.delete(message.id);
+        }
+        if (message.data) {
+          this.requests.get(message.id).resolve(message.data);
+          clearTimeout(request.timeout);
+          return this.requests.delete(message.id);
+        }
+        break;
     }
+    if (process.argv.includes('--dev')) {
+      this.client.log(`[IPCHandler] - Received the message ${message.type} from cluster ${message.clusterID}: ${JSON.stringify(message, null, 2)}`);
+    }
+  }
+
+  /**
+    * Check if all the active clusters responded to a request
+    * @param {String} id - The ID of the request to check if all the clusters answered to
+    * @returns {Boolean} Whether all the clusters responded to the request
+    * @private
+    */
+  _allClustersAnswered (id) {
+    return this.requests.get(id).responses.length >= this.client.config.sharder.clusters;
+  }
+
+  /**
+   *
+   *
+   * @param {Memer} Memer The Memer instance
+   * @param {String} input The code to evaluate
+   * @returns {Promise<String>} The error message, or `Success`
+   * @memberof IPCHandler
+   */
+  async _eval (Memer, input) {
+    const asynchr = input.includes('return') || input.includes('await');
+    let error;
+    try {
+      await eval(asynchr ? `(async()=>{${input}})();` : input) // eslint-disable-line
+    } catch (err) {
+      error = err.message;
+      Memer.log(err, 'error');
+    }
+    return error || 'Success';
+  }
+
+  /**
+   * Makes the given object stringifiable by JSON.stringify() (converting types if necessary)
+   * @param {Object} object The object to make stringifiable
+   * @returns {Object} The given object, but stringifiable
+   */
+  toJSON (object) {
+    const base = {};
+    for (const key in object) {
+      if (!base.hasOwnProperty(key) && object.hasOwnProperty(key) && !key.startsWith('_')) {
+        if (!object[key]) {
+          base[key] = object[key];
+        } else if (object[key] instanceof Set) {
+          base[key] = Array.from(object[key]);
+        } else if (object[key] instanceof Map) {
+          base[key] = Array.from(object[key].values());
+        } else if (typeof object[key].toJSON === 'function') {
+          base[key] = object[key].toJSON();
+        } else {
+          base[key] = object[key];
+        }
+      }
+    }
+    return base;
+  }
 }
 
 module.exports = IPCHandler;

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -354,14 +354,14 @@ class MiscFunctions {
     let name;
     let object;
     if (type === 'user') {
-      object = await Memer.ipc.fetchUser(id);
+      object = await Memer.IPC.fetchUser(id);
       if (!object) {
         name = 'not sure of the username...';
       } else {
         name = `${object.username}#${object.discriminator}`;
       }
     } else {
-      object = await Memer.ipc.fetchGuild(id);
+      object = await Memer.IPC.fetchGuild(id);
       if (!object) {
         name = 'not sure of the server name';
       } else {


### PR DESCRIPTION
This PR implements a custom IPC module under `Memer.IPC`, it is intended to entirely replace eris-sharder's built-in ~~trash~~ IPC module, the key features being:

* Customizable timeout for `fetch<Resource>` methods
* `fetch<Resource>` methods will resolve once all clusters answered even if the resource was not found (so no need for hardcoded timeout)
* new `broadcastEval()` method
* Actually documented
* new `rollingRestart()` method, still a draft, but worked as far as i tested. The restart atm is a reverse-restart, as in the last cluster will be restarted first, this is because atm the first cluster is managing the rolling restart

There's also two new dev commands: `pls d rollingrestart` and `pls d broadcasteval`, both owner only

### Other changes

* Added `guildsPerShard` option to sharder config, not mandatory