### PR TITLE
Add Role Whitelisting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/dank-memer/Dank-Memer.git"
   },
-  "keywords": ["discord"],
+  "keywords": [
+    "discord"
+  ],
   "author": "Melmsie and the crew",
   "license": "MIT",
   "bugs": {
@@ -20,6 +22,7 @@
   "dependencies": {
     "asciiart-logo": "^0.1.7",
     "cheerio": "^1.0.0-rc.2",
+    "eris": "^0.9.0",
     "eris-sharder": "github:Discord-Sharders/eris-sharder#dev",
     "ioredis": "^4.0.0",
     "lavalink": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "asciiart-logo": "^0.1.7",
     "cheerio": "^1.0.0-rc.2",
-    "eris": "^0.9.0",
     "eris-sharder": "github:Discord-Sharders/eris-sharder#dev",
     "ioredis": "^4.0.0",
     "lavalink": "^2.2.2",
@@ -39,6 +38,7 @@
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-import": "^2.14.0",
-    "@types/node": "^10.11.7"
+    "@types/node": "^10.11.7",
+    "eris": "^0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-import": "^2.14.0",
-    "@types/node": "^10.11.7",
-    "eris": "^0.9.0"
+    "@types/node": "^10.11.7"
   }
 }

--- a/src/commands/configCommands/serverconf.js
+++ b/src/commands/configCommands/serverconf.js
@@ -33,6 +33,11 @@ module.exports = new GenericCommand(
           name: 'Enabled Commands',
           value: enabledCommands.map(c => `\`${c}\``).join(', ') || 'No overriding enabled commands',
           inline: true
+        },
+        {
+          name: 'Whitelisted Roles',
+          value: guildEntry.props.whitelistRoles.map(r => `<@&${r}>`).join(', ') || 'Everyone is whitelisted',
+          inline: true
         }
       ]
     };

--- a/src/commands/configCommands/whitelist.js
+++ b/src/commands/configCommands/whitelist.js
@@ -34,27 +34,19 @@ Use \`${guildEntry.props.prefix} whitelist purge\` to remove the entire whitelis
       }
     }
 
-    let response;
-
     switch (args[0]) {
       case 'add':
-        guildEntry.addWhitelistedRole(role.id);
-        response = 'Added that role to the whitelist, welcome to the meme club, kids.';
-        break;
+        await guildEntry.addWhitelistedRole(role.id).save();
+        return 'Added that role to the whitelist, welcome to the meme club, kids.';
       case 'remove':
-        guildEntry.yeetWhitelistedRole(role.id);
-        response = 'Yeeted that role out of the whitelist, if it was even in there.';
-        break;
+        await guildEntry.yeetWhitelistedRole(role.id).save();
+        return 'Yeeted that role out of the whitelist, if it was even in there.';
       case 'purge':
-        guildEntry.purgeWhitelist();
-        response = 'Alright m8, I purged the whole whitelist, all people are free to dab in #general now.';
-        break;
+        await guildEntry.purgeWhitelist().save();
+        return 'Alright m8, I purged the whole whitelist, all people are free to dab in #general now.';
       default:
         return {content: "Oi, that's not a valid command m8, you gotta use `add`, `remove`, or `purge`.", reply: true};
     }
-
-    await guildEntry.save();
-    return response;
   }, {
     triggers: ['whitelist'],
     usage: '{command} <purge/add/remove> [role]',

--- a/src/commands/configCommands/whitelist.js
+++ b/src/commands/configCommands/whitelist.js
@@ -57,6 +57,7 @@ Use \`${guildEntry.props.prefix} whitelist purge\` to remove the entire whitelis
     return response;
   }, {
     triggers: ['whitelist'],
+    usage: '{command} <purge/add/remove> [role]',
     description: 'Use this command to set and manage whitelisted roles of whomst\'ve can use commands'
   }
 );

--- a/src/commands/configCommands/whitelist.js
+++ b/src/commands/configCommands/whitelist.js
@@ -1,0 +1,62 @@
+const {GenericCommand} = require('../../models');
+
+module.exports = new GenericCommand(
+  async ({Memer, msg, args, guildEntry}) => {
+    if (!msg.member.permission.has('manageGuild') && !Memer.config.options.developers.includes(msg.author.id)) {
+      return 'You are not authorized to use this command. You must have `Manage Server` to manage the whitelist.';
+    }
+
+    if (!args[0]) {
+      return {
+        content: `*No first argument detected, entering monologue mode...*
+
+Use this command with multiple sorts of secondary commands: 
+Use \`${guildEntry.props.prefix} whitelist add Mr Memer\` to establish a whitelist and add the role with the name 'Mr Memer'
+Use \`${guildEntry.props.prefix} whitelist remove Mr Memer\` to remove the role with the name 'Mr Memer' from the whitelist, no more memes for you!
+Use \`${guildEntry.props.prefix} whitelist purge\` to remove the entire whitelist and *set everyone free*, raise anarchy, make a meme castle or whatever.`,
+        reply: true
+      };
+    }
+
+    let name;
+    let role;
+
+    if (args[0] === 'add' || args[0] === 'remove') {
+      if (args.length < 2) {
+        return {content: `I need the name of the role, dummy.`, reply: true};
+      } else {
+        name = args.slice(1).join(' ');
+        role = msg.member.guild.roles.find(r => (r.name.toLowerCase() === name.toLowerCase()) || (r.id === name));
+
+        if (!role) {
+          return `No role found with name '${name}', check if you got punctuation alright, it's not case-sensitive.`;
+        }
+      }
+    }
+
+    let response;
+
+    switch (args[0]) {
+      case 'add':
+        guildEntry.addWhitelistedRole(role.id);
+        response = 'Added that role to the whitelist, welcome to the meme club, kids.';
+        break;
+      case 'remove':
+        guildEntry.yeetWhitelistedRole(role.id);
+        response = 'Yeeted that role out of the whitelist, if it was even in there.';
+        break;
+      case 'purge':
+        guildEntry.purgeWhitelist();
+        response = 'Alright m8, I purged the whole whitelist, all people are free to dab in #general now.';
+        break;
+      default:
+        return {content: "Oi, that's not a valid command m8, you gotta use `add`, `remove`, or `purge`.", reply: true};
+    }
+
+    await guildEntry.save();
+    return response;
+  }, {
+    triggers: ['whitelist'],
+    description: 'Use this command to set and manage whitelisted roles of whomst\'ve can use commands'
+  }
+);

--- a/src/handlers/messageCreate.js
+++ b/src/handlers/messageCreate.js
@@ -151,6 +151,19 @@ exports.handle = async function (msg) {
     return;
   }
 
+  if (gConfig.whitelistRoles) {
+    if (msg.member) {
+      if (
+        !msg.member.roles.some(id => gConfig.whitelistRoles.includes(id)) &&
+        !msg.member.permission.has('administrator') // make sure Dank Memer is still accessible to mods lol
+      ) {
+        // this.ddog.increment(`blockedByWhitelist`);
+        // FIXME implement stats for this?
+        return;
+      }
+    }
+  }
+
   let userEntry = await this.db.getUser(msg.author.id);
   userEntry.addPls().setLastCmd(command.props.triggers[0]);
 

--- a/src/models/GuildEntry.js
+++ b/src/models/GuildEntry.js
@@ -7,6 +7,7 @@
  * @prop {Array<String>} disabledCategories An array of disabled command categories on this guild
  * @prop {Array<String>} disabledCommands An array of disabled commands on this guild
  * @prop {Array<String>} enabledCommands An array of commands enabled on this guild, overrides the disabled categories
+ * @prop {Array<String>} whitelistRoles An array of roles to whitelist with commands, will allow @everyone when empty
  * @prop {Object} autoResponse The autoresponse settings
  * @prop {Boolean} autoResponse.dad Whether dad mode is enabled
  * @prop {Boolean} autoResponse.ree Whether auto responses to "ree+" are enabled
@@ -136,6 +137,46 @@ class GuildEntry {
     }
     this.props.disabledCommands.push(command);
     this.update({ disabledCommands: this._client.r.row('disabledCommands').default([]).append(command) });
+    return this;
+  }
+
+  /**
+   * Add a whitelist role
+   * @param {String} role The id of the role to add
+   * @returns {GuildEntry} The guild entry, so calls can be chained
+   */
+  addWhitelistedRole (role) {
+    if (typeof role !== 'string') {
+      throw new Error(`Expected type string, received type ${typeof role}`);
+    }
+
+    this.props.whitelistRoles = this.props.whitelistRoles.concat([role]);
+    this.update({ whitelistRoles: this._client.r.row('whitelistRoles').default([]).setUnion([role]) });
+    return this;
+  }
+
+  /**
+   * Remove a whitelist role
+   * @param {String} role The id of the role to remove
+   * @returns {GuildEntry} The guild entry, so calls can be chained
+   */
+  yeetWhitelistedRole (role) {
+    if (typeof role !== 'string') {
+      throw new Error(`Expected type string, received type ${typeof role}`);
+    }
+
+    this.props.whitelistRoles = this.props.whitelistRoles.filter(c => c !== role);
+    this.update({ whitelistRoles: this._client.r.row('whitelistRoles').default([]).difference([role]) });
+    return this;
+  }
+
+  /**
+   * Purge the entire whitelist
+   * @returns {GuildEntry} The guild entry, so calls can be chained
+   */
+  purgeWhitelist () {
+    this.props.whitelistRoles = [];
+    this.update({ whitelistRoles: [] });
     return this;
   }
 

--- a/src/utils/dbFunctions.js
+++ b/src/utils/dbFunctions.js
@@ -680,6 +680,7 @@ class DatabaseFunctions {
       disabledCategories: [],
       disabledCommands: [],
       enabledCommands: [],
+      whitelistRoles: [],
       autoResponse: {
         dad: false,
         ree: false,


### PR DESCRIPTION
This PR adds:
- `pls whitelist <purge/add/remove> [role]`
- An extra array field per guildEntry
- A check for the whitelist
- Gayness

Essentially if the whitelist array has more than 0 objects in it, it will be enabled, and then only everyone either having that role, or `administrator`, will be allowed to send commands.